### PR TITLE
Add ISO year-week macro

### DIFF
--- a/macros/calendar_date/iso_year_week.sql
+++ b/macros/calendar_date/iso_year_week.sql
@@ -1,0 +1,30 @@
+{# 
+    If 1 January is on a Monday, Tuesday, Wednesday or Thursday, it is in W01. If it is on a Friday, it is part of W53 
+    of the previous year. If it is on a Saturday, it is part of the last week of the previous year which is numbered 
+    W52 in a common year and W53 in a leap year. If it is on a Sunday, it is part of W52 of the previous year. 
+    https://en.wikipedia.org/wiki/ISO_week_date
+
+    Format: YYYY-Www
+#}
+{%- macro iso_year_week(date) -%}
+    {{ adapter.dispatch("iso_year_week", "dbt_date")(datepart, date) }}
+{%- endmacro -%}
+
+{% macro default__date_part(datepart, date) -%}
+
+    case
+        when {{ dbt_date.iso_week_of_year(date) }} = 1
+        then
+            concat(
+                {{ dbt_date.date_part("year", dbt_date.iso_week_end_date(date)) }},
+                '-W',
+                lpad({{ dbt_date.weekiso(date) }}, 2, 0)
+            )
+        else
+            concat(
+                {{ dbt_date.date_part("year", dbt_date.iso_week_start_date(date)) }},
+                '-W',
+                lpad({{ dbt_date.weekiso(date) }}, 2, 0)
+            )
+
+{%- endmacro %}

--- a/macros/get_date_dimension.sql
+++ b/macros/get_date_dimension.sql
@@ -46,6 +46,7 @@
         {{ dbt_date.iso_week_end("d.prior_year_over_year_date_day") }}
         as prior_year_iso_week_end_date,
         {{ dbt_date.iso_week_of_year("d.date_day") }} as iso_week_of_year,
+        {{ dbt_date.iso_year_week("d.date_day") }} as iso_year_week,
 
         {{ dbt_date.week_of_year("d.prior_year_over_year_date_day") }}
         as prior_year_week_of_year,


### PR DESCRIPTION
While there is currently both an ISO year and ISO week macro, this unfortunately does not cover the possibility for combining them into an [ISO year week](https://en.wikipedia.org/wiki/ISO_week_date) as this can lead to duplicates of weeks. E.g. there can be more than 7 days for week 2024-W01 as 2024-12-31 falls in 2025-W01. This macro creates the correct ISO year week combination by taking into account the start and end year of the week.