### PR TITLE
Adding CI for multiple CI versions

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -3,6 +3,7 @@ export DBT_PROFILES_DIR=integration_tests
 
 export DBT_ENV_SECRET_POSTGRES_PASS=dbt
 export POSTGRES_DATABASE=metastore
+export POSTGRES_DB=metastore
 export POSTGRES_HOST=localhost
 export POSTGRES_PORT=5432
 export POSTGRES_SCHEMA=dbt_date

--- a/.github/workflows/ci-mulitple-dbt-versions.yml
+++ b/.github/workflows/ci-mulitple-dbt-versions.yml
@@ -1,0 +1,66 @@
+name: Integration testing (multiple dbt versions)
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  DBT_PROJECT_DIR: integration_tests
+  DBT_PROFILES_DIR: integration_tests
+  DBT_ENV_SECRET_POSTGRES_PASS: dbt
+  POSTGRES_DATABASE: metastore
+  POSTGRES_DB: metastore
+  POSTGRES_HOST: localhost
+  POSTGRES_PORT: 5432
+  POSTGRES_SCHEMA: dbt_date
+  POSTGRES_USER: dbt
+  SPARK_HOST: localhost
+  SPARK_METHOD: thrift
+  SPARK_PORT: 10000
+  SPARK_SCHEMA: dbt_date
+  SPARK_USER: dbt
+
+jobs:
+  integration_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        adapter:
+          - duckdb
+          - postgres
+          - spark
+        dbt-version:
+          - "1.6"
+          - "1.7"
+          - "1.8"
+          - "1.9"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+
+      - name: Install dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }}
+        if: ${{ matrix.adapter == 'spark' }}
+        run: pip install "dbt-${{ matrix.adapter }}[PyHive]~=${{ matrix.dbt-version }}.0" "dbt-core~=${{ matrix.dbt-version }}.0" tox
+
+      - name: Install dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }}
+        if: ${{ matrix.adapter != 'spark' }}
+        run: pip install "dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }}.0" "dbt-core~=${{ matrix.dbt-version }}.0" tox
+
+      - name: Install testing dependencies (non-python)
+        if: ${{ matrix.adapter == 'postgres' || matrix.adapter == 'spark' }}
+        run: |
+          docker compose -f ./integration_tests/docker-compose.yml up -d
+          sleep 5
+
+      - name: Run integration tests (${{ matrix.adapter }})
+        run: |
+          tox -e dbt_integration_${{ matrix.adapter }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request_target:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ integration_tests/docker/
 integration_tests/dbt_packages/
 integration_tests/logs/
 integration_tests/target/
+integration_tests/.user.yml
 logs/
 target/
 .env
+db.duckdb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 	<img src="https://img.shields.io/github/v/tag/godatadriven/dbt-date?logo=github">
-  <img src="https://img.shields.io/badge/dbt--core-%3E=1.2%20%3C=1.9.x-orange?logo=dbt">
+  <img src="https://img.shields.io/badge/dbt--core-%3E=1.6%20%3C=1.9.x-orange?logo=dbt">
 	<img src="https://img.shields.io/badge/license-Apache--2.0-ff69b4?style=plastic">
   <img src="https://img.shields.io/github/last-commit/godatadriven/dbt-date/main">
 </div>
@@ -25,7 +25,7 @@ Include in `packages.yml`
 packages:
   - package: godatadriven/dbt_date
     version: [">=0.11.0", "<0.12.0"]
-    # <see https://github.com/godatadriven/dbt-date/releases/latest> for the latest version tag
+    # <see https://github.com/godatadriven/dbt-date/tags> for the latest version tag
 ```
 
 ## Supported Adapters

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -8,7 +8,7 @@ clean-targets: ["target", "dbt_packages"]
 macro-paths: ["macros"]
 log-path: "logs"
 
-require-dbt-version: [">=1.2.0", "<2.0.0"]
+require-dbt-version: [">=1.6.0", "<2.0.0"]
 profile: integration_tests
 
 quoting:

--- a/integration_tests/profiles.yml
+++ b/integration_tests/profiles.yml
@@ -12,7 +12,7 @@ integration_tests:
 
     duckdb:
       type: "duckdb"
-      path: ":memory:"
+      path: "./db.duckdb"
       threads: 5
 
     postgres:

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ passenv =
     DBT_ENV_SECRET_POSTGRES_PASS
     POSTGRES_PORT
     POSTGRES_DATABASE
+    POSTGRES_DB
     POSTGRES_SCHEMA
 
     SPARK_HOST
@@ -23,10 +24,10 @@ allowlist_externals =
     dbt
 skip_install = true
 commands =
-    dbt --version
     dbt debug --target duckdb
     dbt deps
-    dbt --warn-error build --target duckdb # Running in-memory so need to run and build using same PID
+    dbt run --target duckdb
+    dbt test --target duckdb
 
 [testenv:dbt_integration_postgres]
 changedir = integration_tests
@@ -34,11 +35,10 @@ allowlist_externals =
     dbt
 skip_install = true
 commands =
-    dbt --version
     dbt debug --target postgres
     dbt deps
-    dbt --warn-error run --target postgres
-    dbt --warn-error test --target postgres
+    dbt run --target postgres
+    dbt test --target postgres
 
 [testenv:dbt_integration_spark]
 changedir = integration_tests
@@ -46,8 +46,7 @@ allowlist_externals =
     dbt
 skip_install = true
 commands =
-    dbt --version
     dbt debug --target spark
     dbt deps
-    dbt --warn-error run --target spark
-    dbt --warn-error test --target spark
+    dbt run --target spark
+    dbt test --target spark


### PR DESCRIPTION
* Adding more CI so we can test multiple dbt versions as well as more adapters.
* Removing support for `dbt-core` < 1.6.