### PR TITLE
Fix deprecation in integration_tests

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -27,4 +27,4 @@ vars:
 
 models:
   dbt_date_integration_tests:
-    materialized: "{{ 'ephemeral' if target.name == 'trino' else 'table' }}"
+    +materialized: "{{ 'ephemeral' if target.name == 'trino' else 'table' }}"


### PR DESCRIPTION
Updating the package to remove a deprecation in `integration_tests` so that they work with Fusion