### PR TITLE
compatible with latest JSON schema update: test arguments

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,6 +3,8 @@ version: "0.5.0"
 
 config-version: 2
 
+require-dbt-version: ">=1.10.5"
+
 clean-targets: ["target", "dbt_packages"]
 macro-paths: ["macros"]
 require-dbt-version: [">=1.6.0", "<2.0.0"]

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -14,3 +14,6 @@ quoting:
 
 vars:
   "dbt_date:time_zone": "America/Los_Angeles"
+
+flags:
+  require_generic_test_arguments_property: true

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -14,6 +14,7 @@ clean-targets: ["target", "dbt_modules", "dbt_packages"]
 flags:
   send_anonymous_usage_stats: false
   use_colors: true
+  require_generic_test_arguments_property: true
 
 dispatch:
   - macro_namespace: dbt_date

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -5,6 +5,8 @@ profile: "integration_tests"
 
 config-version: 2
 
+require-dbt-version: ">=1.10.5"
+
 model-paths: ["models"]
 test-paths: ["tests"]
 seed-paths: ["data"]

--- a/integration_tests/models/test_dates.yml
+++ b/integration_tests/models/test_dates.yml
@@ -3,83 +3,113 @@ models:
   - name: test_dates
     tests:
       - expression_is_true:
-          expression: "prior_date_day = {{ dbt_date.yesterday('date_day') }}"
+          arguments:
+            expression: "prior_date_day = {{ dbt_date.yesterday('date_day') }}"
       - expression_is_true:
-          expression: "next_date_day = {{ dbt_date.tomorrow('date_day') }}"
+          arguments:
+            expression: "next_date_day = {{ dbt_date.tomorrow('date_day') }}"
       - expression_is_true:
-          expression: "day_name = {{ dbt_date.day_name('date_day', short=False) }}"
+          arguments:
+            expression: "day_name = {{ dbt_date.day_name('date_day', short=False) }}"
       - expression_is_true:
-          expression: "day_name_short = {{ dbt_date.day_name('date_day', short=True) }}"
+          arguments:
+            expression: "day_name_short = {{ dbt_date.day_name('date_day', short=True) }}"
       - expression_is_true:
-          expression: "day_name_long_dutch = {{ dbt_date.day_name('date_day', short=False, language='nl') }}"
+          arguments:
+            expression: "day_name_long_dutch = {{ dbt_date.day_name('date_day', short=False, language='nl') }}"
       - expression_is_true:
-          expression: "day_name_short_german = {{ dbt_date.day_name('date_day', language='de') }}"
+          arguments:
+            expression: "day_name_short_german = {{ dbt_date.day_name('date_day', language='de') }}"
       - expression_is_true:
-          expression: "day_of_month = {{ dbt_date.day_of_month('date_day') }}"
+          arguments:
+            expression: "day_of_month = {{ dbt_date.day_of_month('date_day') }}"
       - expression_is_true:
-          expression: "day_of_week = {{ dbt_date.day_of_week('date_day', isoweek=False) }}"
+          arguments:
+            expression: "day_of_week = {{ dbt_date.day_of_week('date_day', isoweek=False) }}"
       - expression_is_true:
-          expression: "iso_day_of_week = {{ dbt_date.day_of_week('date_day', isoweek=True) }}"
+          arguments:
+            expression: "iso_day_of_week = {{ dbt_date.day_of_week('date_day', isoweek=True) }}"
       - expression_is_true:
-          expression: "day_of_year = {{ dbt_date.day_of_year('date_day') }}"
-
+          arguments:
+            expression: "day_of_year = {{ dbt_date.day_of_year('date_day') }}"
       - expression_is_true:
-          expression: "week_start_date = {{ dbt_date.week_start('date_day') }}"
+          arguments:
+            expression: "week_start_date = {{ dbt_date.week_start('date_day') }}"
       - expression_is_true:
-          expression: "week_end_date = {{ dbt_date.week_end('date_day') }}"
+          arguments:
+            expression: "week_end_date = {{ dbt_date.week_end('date_day') }}"
       - expression_is_true:
-          expression: "week_of_year = {{ dbt_date.week_of_year('date_day') }}"
+          arguments:
+            expression: "week_of_year = {{ dbt_date.week_of_year('date_day') }}"
       - expression_is_true:
-          expression: "iso_week_start_date = {{ dbt_date.iso_week_start('date_day') }}"
+          arguments:
+            expression: "iso_week_start_date = {{ dbt_date.iso_week_start('date_day') }}"
       - expression_is_true:
-          expression: "iso_week_end_date = {{ dbt_date.iso_week_end('date_day') }}"
+          arguments:
+            expression: "iso_week_end_date = {{ dbt_date.iso_week_end('date_day') }}"
       - expression_is_true:
-          expression: "iso_week_of_year = {{ dbt_date.iso_week_of_year('date_day') }}"
+          arguments:
+            expression: "iso_week_of_year = {{ dbt_date.iso_week_of_year('date_day') }}"
       - expression_is_true:
-          expression: "iso_year_week = {{ dbt_date.iso_year_week('date_day') }}"
+          arguments:
+            expression: "iso_year_week = {{ dbt_date.iso_year_week('date_day') }}"
       - expression_is_true:
-          expression: "month_number = {{ dbt_date.date_part('month', 'date_day') }}"
+          arguments:
+            expression: "month_number = {{ dbt_date.date_part('month', 'date_day') }}"
       - expression_is_true:
-          expression: "month_name = {{ dbt_date.month_name('date_day', short=False) }}"
+          arguments:
+            expression: "month_name = {{ dbt_date.month_name('date_day', short=False) }}"
       - expression_is_true:
-          expression: "month_name_short = {{ dbt_date.month_name('date_day', short=True) }}"
+          arguments:
+            expression: "month_name_short = {{ dbt_date.month_name('date_day', short=True) }}"
       - expression_is_true:
-          expression: "month_name_dutch = {{ dbt_date.month_name('date_day', short=False, language='nl') }}"
+          arguments:
+            expression: "month_name_dutch = {{ dbt_date.month_name('date_day', short=False, language='nl') }}"
       - expression_is_true:
-          expression: "month_name_short_german = {{ dbt_date.month_name('date_day', language='de') }}"
+          arguments:
+            expression: "month_name_short_german = {{ dbt_date.month_name('date_day', language='de') }}"
       - expression_is_true:
-          expression: "time_stamp_utc = {{ dbt_date.from_unixtimestamp('unix_epoch') }}"
+          arguments:
+            expression: "time_stamp_utc = {{ dbt_date.from_unixtimestamp('unix_epoch') }}"
       - expression_is_true:
-          expression: "unix_epoch = {{ dbt_date.to_unixtimestamp('time_stamp_utc') }}"
+          arguments:
+            expression: "unix_epoch = {{ dbt_date.to_unixtimestamp('time_stamp_utc') }}"
       - expression_is_true:
-          expression: "time_stamp = {{ dbt_date.convert_timezone('time_stamp_utc') }}"
+          arguments:
+            expression: "time_stamp = {{ dbt_date.convert_timezone('time_stamp_utc') }}"
       - expression_is_true:
-          expression: "time_stamp = {{ dbt_date.convert_timezone('time_stamp_utc', source_tz='UTC') }}"
-      # - expression_is_true:
-      #     expression: "time_stamp_utc = {{ dbt_date.convert_timezone('time_stamp', source_tz='America/Los_Angeles', target_tz='UTC') }}"
-      # - expression_is_true:
-      #     expression: "time_stamp = {{ dbt_date.convert_timezone('time_stamp', source_tz='America/Los_Angeles', target_tz='America/Los_Angeles') }}"
+          arguments:
+            expression: "time_stamp = {{ dbt_date.convert_timezone('time_stamp_utc', source_tz='UTC') }}"
       - expression_is_true:
-          expression: "rounded_timestamp = {{ dbt_date.round_timestamp('time_stamp') }}"
+          arguments:
+            expression: "rounded_timestamp = {{ dbt_date.round_timestamp('time_stamp') }}"
       - expression_is_true:
-          expression: "rounded_timestamp_utc = {{ dbt_date.round_timestamp('time_stamp_utc') }}"
+          arguments:
+            expression: "rounded_timestamp_utc = {{ dbt_date.round_timestamp('time_stamp_utc') }}"
       - expression_is_true:
-          expression: "last_month_number = {{ dbt_date.last_month_number() }}"
+          arguments:
+            expression: "last_month_number = {{ dbt_date.last_month_number() }}"
       - expression_is_true:
-          expression: "last_month_name = {{ dbt_date.last_month_name(short=False) }}"
+          arguments:
+            expression: "last_month_name = {{ dbt_date.last_month_name(short=False) }}"
       - expression_is_true:
-          expression: "last_month_name_short = {{ dbt_date.last_month_name(short=True) }}"
+          arguments:
+            expression: "last_month_name_short = {{ dbt_date.last_month_name(short=True) }}"
       - expression_is_true:
-          expression: "next_month_number = {{ dbt_date.next_month_number() }}"
+          arguments:
+            expression: "next_month_number = {{ dbt_date.next_month_number() }}"
       - expression_is_true:
-          expression: "next_month_name = {{ dbt_date.next_month_name(short=False) }}"
+          arguments:
+            expression: "next_month_name = {{ dbt_date.next_month_name(short=False) }}"
       - expression_is_true:
-          expression: "next_month_name_short = {{ dbt_date.next_month_name(short=True) }}"
+          arguments:
+            expression: "next_month_name_short = {{ dbt_date.next_month_name(short=True) }}"
       - expression_is_true:
-          expression: "datetime_date = cast('{{ dbt_date.date(1997, 9, 29) }}' as date)"
+          arguments:
+            expression: "datetime_date = cast('{{ dbt_date.date(1997, 9, 29) }}' as date)"
       - expression_is_true:
-          expression: "datetime_datetime = cast('{{ dbt_date.datetime(1997, 9, 29, 6, 14) }}' as {{ dbt.type_timestamp() }})"
-
+          arguments:
+            expression: "datetime_datetime = cast('{{ dbt_date.datetime(1997, 9, 29, 6, 14) }}' as {{ dbt.type_timestamp() }})"
     columns:
       - name: date_day
       - name: prior_date_day


### PR DESCRIPTION
follow on to #22 and #23

dbt Core and dbt Fusion have deprecated test arguments at the top-level of the `test:`([docs](https://docs.getdbt.com/reference/deprecations#missingargumentspropertyingenerictestdeprecation)).

This landed in dbt Core `1.10.5` ([release notes](https://github.com/dbt-labs/dbt-core/releases/tag/v1.10.5))

this pr does two things:
1. adds the required flag for test args
2. moves test args to their new homes
3. updates the minimum required version of the package to be `1.10.5` so that
  1. Fusion users can use the package
  2. dbt Core users won't be able to install the package unless they are on the version that contains this authoring layer change