### PR TITLE
Remove duplicate require-dbt-version entry

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,11 +3,9 @@ version: "0.5.0"
 
 config-version: 2
 
-require-dbt-version: ">=1.10.5"
-
 clean-targets: ["target", "dbt_packages"]
 macro-paths: ["macros"]
-require-dbt-version: [">=1.6.0", "<2.0.0"]
+require-dbt-version: ">=1.10.5"
 profile: integration_tests
 
 quoting:


### PR DESCRIPTION
#25 changed the `require-dbt-version`, but incorrectly added a second copy of the config, not modifying the existing one. 

Because it was earlier in the file, and last write wins for the package hub's YAML parser, this setting was overwritten, leading to https://github.com/metaplane/dbt-expectations/issues/26

I've verified that this PR works correctly: 

```
(dbt-prod) joel@Joel-Labes dbt-date % pip install dbt-core==1.10.4
[...]
(dbt-prod) joel@Joel-Labes dbt-date % dbt parse                   
03:27:36  Running with dbt=1.10.4
03:27:36  Encountered an error:
Runtime Error
  This version of dbt is not supported with the 'dbt_date' package.
    Installed version of dbt: =1.10.4
    Required version of dbt for 'dbt_date': ['>=1.10.5']
  Check for a different version of the 'dbt_date' package, or run dbt again with --no-version-check
```

```
(dbt-prod) joel@Joel-Labes dbt-date % pip install dbt-core==1.10.5
[...]
(dbt-prod) joel@Joel-Labes dbt-date % dbt parse                   
03:29:45  Running with dbt=1.10.5
03:29:45  Registered adapter: snowflake=1.10.0
03:29:45  Unable to do partial parsing because of a version mismatch
03:29:46  Performance info: /Users/joel/Documents/GitHub/dbt-date/target/perf_info.json
```