### PR TITLE
Updating required version to allow Fusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .tox/
 .venv/
 dbt_date.egg-info/
+dbt_internal_packages/
 dbt_packages/
 integration_tests/.hive-metastore/
 integration_tests/.spark-warehouse/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -5,7 +5,7 @@ config-version: 2
 
 clean-targets: ["target", "dbt_packages"]
 macro-paths: ["macros"]
-require-dbt-version: ">=1.10.5"
+require-dbt-version: [">=1.10.5", "<3.0.0"]
 profile: integration_tests
 
 quoting:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -5,7 +5,7 @@ profile: "integration_tests"
 
 config-version: 2
 
-require-dbt-version: ">=1.10.5"
+require-dbt-version: [">=1.10.5", "<3.0.0"]
 
 model-paths: ["models"]
 test-paths: ["tests"]


### PR DESCRIPTION
dbt Labs have asked package maintainers to mark their packages as compatible with Fusion. `dbt-date` is already compatible ([source](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-fusion#package-support)) so this PR has no real impact other than aligning with how this is recommended to be done ([example](https://github.com/dbt-labs/dbt-utils/pull/1057)).

There is no CI for Fusion compatibility. I'm currently debating how to do this with dbt so I expect this will be added in the future.