### PR TITLE
build: update dbt_project version to be consistent with release version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "dbt_date"
-version: "0.5.0"
+version: "0.17.0"
 
 config-version: 2
 


### PR DESCRIPTION
## What was done

I imagine that the version in the `dbt_project.yml` should be the same as the release version. Correcting it.