### PR TITLE
ci: use ubuntu-slim

### DIFF
--- a/.github/workflows/ci-mulitple-dbt-versions.yml
+++ b/.github/workflows/ci-mulitple-dbt-versions.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   integration_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## What was done

Use `ubuntu-slim` in the Github Actions workflows.

See [here](https://github.com/godatadriven/dbt-date/actions) how much it took to run previous GitHub Actions worflows

Inspiration:

https://github.com/yu-iskw/dbt-artifacts-parser/pull/191/files

Reference:

https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/