### PR TITLE
Revert "ci: use ubuntu-slim"

### DIFF
--- a/.github/workflows/ci-mulitple-dbt-versions.yml
+++ b/.github/workflows/ci-mulitple-dbt-versions.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   integration_tests:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Reverts godatadriven/dbt-date#42 as `Docker` is not packaged in `ubuntu-slim` and so the [pipelines](https://github.com/godatadriven/dbt-date/actions/runs/20066319827) are failing.