### PR TITLE
Make date() and datetime() macros dispatchable

### DIFF
--- a/macros/_utils/modules_datetime.sql
+++ b/macros/_utils/modules_datetime.sql
@@ -1,11 +1,19 @@
 {% macro date(year, month, day) %}
-    {{ return(modules.datetime.date(year, month, day)) }}
+  {{ return(adapter.dispatch("date", "dbt_date")(year, month, day)) }}
+{% endmacro %}
+
+{% macro default__date(year, month, day) %}
+  {{ return(modules.datetime.date(year, month, day)) }}
 {% endmacro %}
 
 {% macro datetime(
     year, month, day, hour=0, minute=0, second=0, microsecond=0, tz=None
 ) %}
-    {% set tz = tz if tz else var("dbt_date:time_zone") %}
+  {{ return(adapter.dispatch("datetime", "dbt_date")(year, month, day, hour, minute, second, microsecond, tz)) }}
+{% endmacro %}
+
+{% macro default__datetime(year, month, day, hour, minute, second, microsecond, tz) %}
+  {% set tz = tz if tz else var("dbt_date:time_zone") %}
     {{
         return(
             modules.datetime.datetime(


### PR DESCRIPTION
## Summary

- Wraps `date()` and `datetime()` macros with `adapter.dispatch()` so adapter-specific packages can override them
- Existing behaviour preserved in `default__date()` and `default__datetime()` — non-breaking change
- Enables databases with timezone-naive timestamp types (e.g. Exasol) to provide clean overrides without patching the installed package

Closes #47

## Test plan

- [ ] Verify existing integration tests pass unchanged (default implementations are identical to the originals)
- [ ] Confirm `adapter.dispatch` resolves to `default__date` / `default__datetime` when no adapter override is registered