### PR TITLE
Make get_fiscal_periods dispatchable for adapter compatibility

### DIFF
--- a/macros/fiscal_date/get_fiscal_periods.sql
+++ b/macros/fiscal_date/get_fiscal_periods.sql
@@ -1,4 +1,8 @@
 {% macro get_fiscal_periods(dates, year_end_month, week_start_day, shift_year=1) %}
+    {{ return(adapter.dispatch('get_fiscal_periods', 'dbt_date')(dates, year_end_month, week_start_day, shift_year)) }}
+{% endmacro %}
+
+{% macro default__get_fiscal_periods(dates, year_end_month, week_start_day, shift_year=1) %}
     {#
 This macro requires you to pass in a ref to a date dimension, created via
 dbt_date.get_date_dimension()s


### PR DESCRIPTION
## Summary

- Wraps `get_fiscal_periods` in `adapter.dispatch()` so adapters can provide dialect-specific overrides
- Moves the existing implementation into `default__get_fiscal_periods` (no behavior change for current users)
- Enables adapters like dbt-fabric to override `mod()` usage without duplicating the entire model

Closes #49

## Details

The `get_fiscal_periods` macro uses `mod(x, y)` which is not available in all SQL dialects (e.g., T-SQL uses `x % y`). Because the macro was called directly without dispatch, adapters had no way to provide their own implementation.

This follows the same pattern used by `get_fiscal_year_dates` and the recently-dispatched `date()` / `datetime()` macros (#48).

## Test plan

- [ ] Existing integration tests pass unchanged (the dispatch wrapper calls `default__get_fiscal_periods` which is the original implementation)
- [ ] Adapters can now override via `fabric__get_fiscal_periods` (or similar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)