### PR TITLE
Ignore Fusion BigQuery service-account keyfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ integration_tests/dbt_packages/
 integration_tests/logs/
 integration_tests/target/
 integration_tests/.user.yml
+integration_tests/service-key-file.json
 logs/
 target/
 .env


### PR DESCRIPTION
The `fusion_integration_bigquery` tox environment expects a BigQuery service-account JSON at `integration_tests/service-key-file.json` (CI writes it from a base64-encoded secret before running). Add it to `.gitignore` so local copies created for that workflow are never committed.