### PR TITLE
Fix malformed if: condition in Fusion BigQuery keyfile step

### DIFF
--- a/.github/workflows/ci-multiple-dbt-versions.yml
+++ b/.github/workflows/ci-multiple-dbt-versions.yml
@@ -107,7 +107,7 @@ jobs:
 
       # Fusion for BigQuery requires a different auth method
       - name: Save BigQuery key file as a file
-        if: ${{ matrix.adapter }} == 'bigquery'
+        if: ${{ matrix.adapter == 'bigquery' }}
         run: |
           echo -n "${{ secrets.BIGQUERY_KEYFILE_JSON_BASE64 }}" | base64 --decode >> ./integration_tests/service-key-file.json
 


### PR DESCRIPTION
The `Save BigQuery key file as a file` step in the `integration_tests_fusion` job used:

```yaml
if: ${{ matrix.adapter }} == 'bigquery'
```

GitHub Actions substitutes `${{ matrix.adapter }}` first, leaving the literal expression `bigquery == 'bigquery'` — a bare unquoted identifier on the left side, which is not a valid GHA expression. Behaviour is undefined: depending on parser path the step either always runs (writing the keyfile even for the `databricks` matrix entry) or always skips (in which case BigQuery Fusion auth would fail).

Wrap the full comparison in `${{ ... }}` to match the convention used elsewhere in this file (see lines 67 and 71):

```yaml
if: ${{ matrix.adapter == 'bigquery' }}
```

Spotted while reviewing #52 — this is a pre-existing issue, unrelated to that PR's changes, so it's split out into its own branch off `main`.
