### PR TITLE
Make remaining calendar_date macros dispatchable

### DIFF
--- a/macros/calendar_date/day_of_month.sql
+++ b/macros/calendar_date/day_of_month.sql
@@ -1,4 +1,10 @@
-{%- macro day_of_month(date) -%} {{ dbt_date.date_part("day", date) }} {%- endmacro %}
+{%- macro day_of_month(date) -%}
+    {{ return(adapter.dispatch("day_of_month", "dbt_date")(date)) }}
+{%- endmacro %}
+
+{%- macro default__day_of_month(date) -%}
+    {{ dbt_date.date_part("day", date) }}
+{%- endmacro %}
 
 {%- macro redshift__day_of_month(date) -%}
     cast({{ dbt_date.date_part("day", date) }} as {{ dbt.type_bigint() }})

--- a/macros/calendar_date/last_month.sql
+++ b/macros/calendar_date/last_month.sql
@@ -1,1 +1,7 @@
-{%- macro last_month(tz=None) -%} {{ dbt_date.n_months_ago(1, tz) }} {%- endmacro -%}
+{%- macro last_month(tz=None) -%}
+    {{ return(adapter.dispatch("last_month", "dbt_date")(tz)) }}
+{%- endmacro -%}
+
+{%- macro default__last_month(tz=None) -%}
+    {{ dbt_date.n_months_ago(1, tz) }}
+{%- endmacro -%}

--- a/macros/calendar_date/last_month_name.sql
+++ b/macros/calendar_date/last_month_name.sql
@@ -1,3 +1,7 @@
 {%- macro last_month_name(short=True, tz=None) -%}
+    {{ return(adapter.dispatch("last_month_name", "dbt_date")(short, tz)) }}
+{%- endmacro -%}
+
+{%- macro default__last_month_name(short=True, tz=None) -%}
     {{ dbt_date.month_name(dbt_date.last_month(tz), short=short) }}
 {%- endmacro -%}

--- a/macros/calendar_date/last_month_number.sql
+++ b/macros/calendar_date/last_month_number.sql
@@ -1,3 +1,7 @@
 {%- macro last_month_number(tz=None) -%}
+    {{ return(adapter.dispatch("last_month_number", "dbt_date")(tz)) }}
+{%- endmacro -%}
+
+{%- macro default__last_month_number(tz=None) -%}
     {{ dbt_date.date_part("month", dbt_date.last_month(tz)) }}
 {%- endmacro -%}

--- a/macros/calendar_date/last_week.sql
+++ b/macros/calendar_date/last_week.sql
@@ -1,1 +1,7 @@
-{%- macro last_week(tz=None) -%} {{ dbt_date.n_weeks_ago(1, tz) }} {%- endmacro -%}
+{%- macro last_week(tz=None) -%}
+    {{ return(adapter.dispatch("last_week", "dbt_date")(tz)) }}
+{%- endmacro -%}
+
+{%- macro default__last_week(tz=None) -%}
+    {{ dbt_date.n_weeks_ago(1, tz) }}
+{%- endmacro -%}

--- a/macros/calendar_date/n_days_ago.sql
+++ b/macros/calendar_date/n_days_ago.sql
@@ -1,4 +1,8 @@
 {%- macro n_days_ago(n, date=None, tz=None) -%}
+    {{ return(adapter.dispatch("n_days_ago", "dbt_date")(n, date, tz)) }}
+{%- endmacro -%}
+
+{%- macro default__n_days_ago(n, date=None, tz=None) -%}
     {%- set dt = date if date else dbt_date.today(tz) -%}
     {%- set n = n | int -%}
     cast({{ dbt.dateadd("day", -1 * n, dt) }} as date)

--- a/macros/calendar_date/n_days_away.sql
+++ b/macros/calendar_date/n_days_away.sql
@@ -1,3 +1,7 @@
 {%- macro n_days_away(n, date=None, tz=None) -%}
+    {{ return(adapter.dispatch("n_days_away", "dbt_date")(n, date, tz)) }}
+{%- endmacro -%}
+
+{%- macro default__n_days_away(n, date=None, tz=None) -%}
     {{ dbt_date.n_days_ago(-1 * n, date, tz) }}
 {%- endmacro -%}

--- a/macros/calendar_date/n_months_ago.sql
+++ b/macros/calendar_date/n_months_ago.sql
@@ -1,4 +1,8 @@
 {%- macro n_months_ago(n, tz=None) -%}
+    {{ return(adapter.dispatch("n_months_ago", "dbt_date")(n, tz)) }}
+{%- endmacro -%}
+
+{%- macro default__n_months_ago(n, tz=None) -%}
     {%- set n = n | int -%}
     {{ dbt.date_trunc("month", dbt.dateadd("month", -1 * n, dbt_date.today(tz))) }}
 {%- endmacro -%}

--- a/macros/calendar_date/n_months_away.sql
+++ b/macros/calendar_date/n_months_away.sql
@@ -1,4 +1,8 @@
 {%- macro n_months_away(n, tz=None) -%}
+    {{ return(adapter.dispatch("n_months_away", "dbt_date")(n, tz)) }}
+{%- endmacro -%}
+
+{%- macro default__n_months_away(n, tz=None) -%}
     {%- set n = n | int -%}
     {{ dbt.date_trunc("month", dbt.dateadd("month", n, dbt_date.today(tz))) }}
 {%- endmacro -%}

--- a/macros/calendar_date/n_weeks_ago.sql
+++ b/macros/calendar_date/n_weeks_ago.sql
@@ -1,4 +1,8 @@
 {%- macro n_weeks_ago(n, tz=None) -%}
+    {{ return(adapter.dispatch("n_weeks_ago", "dbt_date")(n, tz)) }}
+{%- endmacro -%}
+
+{%- macro default__n_weeks_ago(n, tz=None) -%}
     {%- set n = n | int -%}
     {{ dbt.date_trunc("week", dbt.dateadd("week", -1 * n, dbt_date.today(tz))) }}
 {%- endmacro -%}

--- a/macros/calendar_date/n_weeks_away.sql
+++ b/macros/calendar_date/n_weeks_away.sql
@@ -1,4 +1,8 @@
 {%- macro n_weeks_away(n, tz=None) -%}
+    {{ return(adapter.dispatch("n_weeks_away", "dbt_date")(n, tz)) }}
+{%- endmacro -%}
+
+{%- macro default__n_weeks_away(n, tz=None) -%}
     {%- set n = n | int -%}
     {{ dbt.date_trunc("week", dbt.dateadd("week", n, dbt_date.today(tz))) }}
 {%- endmacro -%}

--- a/macros/calendar_date/next_month.sql
+++ b/macros/calendar_date/next_month.sql
@@ -1,1 +1,7 @@
-{%- macro next_month(tz=None) -%} {{ dbt_date.n_months_away(1, tz) }} {%- endmacro -%}
+{%- macro next_month(tz=None) -%}
+    {{ return(adapter.dispatch("next_month", "dbt_date")(tz)) }}
+{%- endmacro -%}
+
+{%- macro default__next_month(tz=None) -%}
+    {{ dbt_date.n_months_away(1, tz) }}
+{%- endmacro -%}

--- a/macros/calendar_date/next_month_name.sql
+++ b/macros/calendar_date/next_month_name.sql
@@ -1,3 +1,7 @@
 {%- macro next_month_name(short=True, tz=None) -%}
+    {{ return(adapter.dispatch("next_month_name", "dbt_date")(short, tz)) }}
+{%- endmacro -%}
+
+{%- macro default__next_month_name(short=True, tz=None) -%}
     {{ dbt_date.month_name(dbt_date.next_month(tz), short=short) }}
 {%- endmacro -%}

--- a/macros/calendar_date/next_month_number.sql
+++ b/macros/calendar_date/next_month_number.sql
@@ -1,3 +1,7 @@
 {%- macro next_month_number(tz=None) -%}
+    {{ return(adapter.dispatch("next_month_number", "dbt_date")(tz)) }}
+{%- endmacro -%}
+
+{%- macro default__next_month_number(tz=None) -%}
     {{ dbt_date.date_part("month", dbt_date.next_month(tz)) }}
 {%- endmacro -%}

--- a/macros/calendar_date/next_week.sql
+++ b/macros/calendar_date/next_week.sql
@@ -1,1 +1,7 @@
-{%- macro next_week(tz=None) -%} {{ dbt_date.n_weeks_away(1, tz) }} {%- endmacro -%}
+{%- macro next_week(tz=None) -%}
+    {{ return(adapter.dispatch("next_week", "dbt_date")(tz)) }}
+{%- endmacro -%}
+
+{%- macro default__next_week(tz=None) -%}
+    {{ dbt_date.n_weeks_away(1, tz) }}
+{%- endmacro -%}

--- a/macros/calendar_date/now.sql
+++ b/macros/calendar_date/now.sql
@@ -1,3 +1,7 @@
 {%- macro now(tz=None) -%}
+    {{ return(adapter.dispatch("now", "dbt_date")(tz)) }}
+{%- endmacro -%}
+
+{%- macro default__now(tz=None) -%}
     {{ dbt_date.convert_timezone(dbt.current_timestamp(), tz) }}
 {%- endmacro -%}

--- a/macros/calendar_date/periods_since.sql
+++ b/macros/calendar_date/periods_since.sql
@@ -1,3 +1,11 @@
 {%- macro periods_since(date_col, period_name="day", tz=None) -%}
+    {{
+        return(
+            adapter.dispatch("periods_since", "dbt_date")(date_col, period_name, tz)
+        )
+    }}
+{%- endmacro -%}
+
+{%- macro default__periods_since(date_col, period_name="day", tz=None) -%}
     {{ dbt.datediff(date_col, dbt_date.now(tz), period_name) }}
 {%- endmacro -%}

--- a/macros/calendar_date/round_timestamp.sql
+++ b/macros/calendar_date/round_timestamp.sql
@@ -1,3 +1,7 @@
 {% macro round_timestamp(timestamp) %}
+    {{ return(adapter.dispatch("round_timestamp", "dbt_date")(timestamp)) }}
+{% endmacro %}
+
+{% macro default__round_timestamp(timestamp) %}
     {{ dbt.date_trunc("day", dbt.dateadd("hour", 12, timestamp)) }}
 {% endmacro %}

--- a/macros/calendar_date/today.sql
+++ b/macros/calendar_date/today.sql
@@ -1,1 +1,7 @@
-{%- macro today(tz=None) -%} cast({{ dbt_date.now(tz) }} as date) {%- endmacro -%}
+{%- macro today(tz=None) -%}
+    {{ return(adapter.dispatch("today", "dbt_date")(tz)) }}
+{%- endmacro -%}
+
+{%- macro default__today(tz=None) -%}
+    cast({{ dbt_date.now(tz) }} as date)
+{%- endmacro -%}

--- a/macros/calendar_date/tomorrow.sql
+++ b/macros/calendar_date/tomorrow.sql
@@ -1,3 +1,7 @@
 {%- macro tomorrow(date=None, tz=None) -%}
+    {{ return(adapter.dispatch("tomorrow", "dbt_date")(date, tz)) }}
+{%- endmacro -%}
+
+{%- macro default__tomorrow(date=None, tz=None) -%}
     {{ dbt_date.n_days_away(1, date, tz) }}
 {%- endmacro -%}

--- a/macros/calendar_date/yesterday.sql
+++ b/macros/calendar_date/yesterday.sql
@@ -1,3 +1,7 @@
 {%- macro yesterday(date=None, tz=None) -%}
+    {{ return(adapter.dispatch("yesterday", "dbt_date")(date, tz)) }}
+{%- endmacro -%}
+
+{%- macro default__yesterday(date=None, tz=None) -%}
     {{ dbt_date.n_days_ago(1, date, tz) }}
 {%- endmacro -%}


### PR DESCRIPTION
Wraps 21 user-facing macros in `adapter.dispatch()` and moves the existing implementations into `default__` variants. This follows the same pattern adopted in #48 (`date` / `datetime`) and #50 (`get_fiscal_periods`), bringing the rest of the package in line so end users and adapter-specific packages can override any macro without forking.

## Macros affected

`day_of_month`, `last_month`, `last_month_name`, `last_month_number`, `last_week`, `n_days_ago`, `n_days_away`, `n_months_ago`, `n_months_away`, `n_weeks_ago`, `n_weeks_away`, `next_month`, `next_month_name`, `next_month_number`, `next_week`, `now`, `periods_since`, `round_timestamp`, `today`, `tomorrow`, `yesterday`.

## Notes

- All defaults are byte-equivalent to the previous implementations, so existing behaviour is preserved.
- `day_of_month.sql` previously defined a `redshift__day_of_month` override that was never invoked because the entry macro called the default logic directly. Adding the dispatch wrapper means that override is now actually used on Redshift — flagging in case reviewers want to confirm that was the original intent.