### PR TITLE
Add support for ClickHouse

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -32,3 +32,8 @@ export TRINO_METHOD=none
 export TRINO_SCHEMA=dbt
 export TRINO_TIMEZONE='UTC'
 export TRINO_USER=dbt
+
+export CLICKHOUSE_HOST=localhost
+export CLICKHOUSE_PORT=8123
+export CLICKHOUSE_SCHEMA=dbt_date
+export CLICKHOUSE_USER=default

--- a/.env_example
+++ b/.env_example
@@ -5,6 +5,11 @@ export BIGQUERY_PROJECT=dbt-date
 export BIGQUERY_SCHEMA=dbt_date
 export BIGQUERY_KEYFILE_JSON='''{<EXAMPLE>}'''
 
+export CLICKHOUSE_HOST=localhost
+export CLICKHOUSE_PORT=8123
+export CLICKHOUSE_SCHEMA=dbt_date
+export CLICKHOUSE_USER=default
+
 export DATABRICKS_CATALOG="<EXAMPLE>"
 export DATABRICKS_SCHEMA="<EXAMPLE>"
 export DATABRICKS_HOST="<EXAMPLE>"
@@ -32,8 +37,3 @@ export TRINO_METHOD=none
 export TRINO_SCHEMA=dbt
 export TRINO_TIMEZONE='UTC'
 export TRINO_USER=dbt
-
-export CLICKHOUSE_HOST=localhost
-export CLICKHOUSE_PORT=8123
-export CLICKHOUSE_SCHEMA=dbt_date
-export CLICKHOUSE_USER=default

--- a/.github/workflows/ci-multiple-dbt-versions.yml
+++ b/.github/workflows/ci-multiple-dbt-versions.yml
@@ -38,6 +38,10 @@ env:
   TRINO_SCHEMA: dbt
   TRINO_TIMEZONE: UTC
   TRINO_USER: dbt
+  CLICKHOUSE_HOST: localhost
+  CLICKHOUSE_PORT: "8123"
+  CLICKHOUSE_SCHEMA: dbt_date
+  CLICKHOUSE_USER: default
 
 jobs:
   integration_tests:
@@ -49,6 +53,7 @@ jobs:
       matrix:
         adapter:
           - bigquery
+          - clickhouse
           - databricks
           - duckdb
           - postgres
@@ -72,7 +77,7 @@ jobs:
         run: pip install "dbt-${{ matrix.adapter }}" "dbt-core~=${{ matrix.dbt-version }}" tox
 
       - name: Install testing dependencies (non-python)
-        if: ${{ matrix.adapter == 'postgres' || matrix.adapter == 'spark' || matrix.adapter == 'trino' }}
+        if: ${{ matrix.adapter == 'postgres' || matrix.adapter == 'spark' || matrix.adapter == 'trino' || matrix.adapter == 'clickhouse' }}
         run: |
           docker compose -f ./integration_tests/docker-compose.yml up -d dbt-${{ matrix.adapter }}
           sleep 30

--- a/.github/workflows/ci-multiple-dbt-versions.yml
+++ b/.github/workflows/ci-multiple-dbt-versions.yml
@@ -15,6 +15,10 @@ env:
   BIGQUERY_PROJECT: dbt-date
   BIGQUERY_KEYFILE_JSON: ${{ secrets.BIGQUERY_KEYFILE_JSON }}
   BIGQUERY_SCHEMA: "integration_tests_bigquery_${{ github.run_number }}"
+  CLICKHOUSE_HOST: localhost
+  CLICKHOUSE_PORT: "8123"
+  CLICKHOUSE_SCHEMA: dbt_date
+  CLICKHOUSE_USER: default
   DBT_ENV_SECRET_DATABRICKS_TOKEN: "${{ secrets.DBT_ENV_SECRET_DATABRICKS_TOKEN }}"
   DATABRICKS_HTTP_PATH: "${{ vars.DATABRICKS_HTTP_PATH }}"
   DATABRICKS_HOST: "${{ vars.DATABRICKS_HOST }}"
@@ -38,11 +42,6 @@ env:
   TRINO_SCHEMA: dbt
   TRINO_TIMEZONE: UTC
   TRINO_USER: dbt
-  CLICKHOUSE_HOST: localhost
-  CLICKHOUSE_PORT: "8123"
-  CLICKHOUSE_SCHEMA: dbt_date
-  CLICKHOUSE_USER: default
-
 jobs:
   integration_tests:
     runs-on: ubuntu-latest
@@ -77,7 +76,7 @@ jobs:
         run: pip install "dbt-${{ matrix.adapter }}" "dbt-core~=${{ matrix.dbt-version }}" tox
 
       - name: Install testing dependencies (non-python)
-        if: ${{ matrix.adapter == 'postgres' || matrix.adapter == 'spark' || matrix.adapter == 'trino' || matrix.adapter == 'clickhouse' }}
+        if: ${{ matrix.adapter == 'clickhouse' || matrix.adapter == 'postgres' || matrix.adapter == 'spark' || matrix.adapter == 'trino' }}
         run: |
           docker compose -f ./integration_tests/docker-compose.yml up -d dbt-${{ matrix.adapter }}
           sleep 30

--- a/.github/workflows/ci-multiple-dbt-versions.yml
+++ b/.github/workflows/ci-multiple-dbt-versions.yml
@@ -69,11 +69,11 @@ jobs:
 
       - name: Install dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }} (including Spark extra)
         if: ${{ matrix.adapter == 'spark' }}
-        run: pip install "dbt-${{ matrix.adapter }}[PyHive]" "dbt-core~=${{ matrix.dbt-version }}" tox
+        run: pip install "dbt-${{ matrix.adapter }}[PyHive]~=${{ matrix.dbt-version }}.0" "dbt-core~=${{ matrix.dbt-version }}.0" tox
 
       - name: Install dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }}
         if: ${{ matrix.adapter != 'spark' && !(matrix.adapter == 'bigquery' && matrix.dbt-version == '1.6') }}
-        run: pip install "dbt-${{ matrix.adapter }}" "dbt-core~=${{ matrix.dbt-version }}" tox
+        run: pip install "dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }}.0" "dbt-core~=${{ matrix.dbt-version }}.0" tox
 
       - name: Install testing dependencies (non-python)
         if: ${{ matrix.adapter == 'clickhouse' || matrix.adapter == 'postgres' || matrix.adapter == 'spark' || matrix.adapter == 'trino' }}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ packages:
 | Adapter    | Full Support       | Partial Support    |
 | ---------- | ------------------ | ------------------ |
 | BigQuery   | :white_check_mark: |                    |
+| ClickHouse | :white_check_mark: |                    |
 | Databricks | :white_check_mark: |                    |
 | DuckDB     | :white_check_mark: |                    |
 | Postgres   | :white_check_mark: |                    |
@@ -854,6 +855,13 @@ or, optionally, you can override the default timezone:
 ```sql
 {% set datetime_object = dbt_date.datetime(1997, 9, 29, 6, 14, tz='America/New_York') %}
 ```
+
+> **ClickHouse note:** `datetime()` returns a timezone-aware value, so its string form
+> includes a UTC offset (e.g. `1997-09-29 06:14:00-07:53`). If you cast that string to a
+> ClickHouse `DateTime` (e.g. `cast('{{ dbt_date.datetime(...) }}' as {{ dbt.type_timestamp() }})`),
+> ClickHouse versions before 26.5 can't parse the offset with the default parser. Either
+> use ClickHouse >= 26.5, set `cast_string_to_date_time_mode: best_effort` in your
+> profile's `custom_settings`, or pass a value without a timezone.
 
 ## Contributing
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 dbt-bigquery>=1.10.0,<1.11.0
+dbt-clickhouse>=1.10.0,<1.11.0
 dbt-core>=1.10.5,<1.11.0
 dbt-databricks>=1.10.0,<1.11.0
 dbt-duckdb>=1.9.0,<1.11.0

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -23,3 +23,16 @@ services:
     image: trinodb/trino:latest
     ports:
       - "8080:8080"
+
+  dbt-clickhouse:
+    image: clickhouse/clickhouse-server:latest
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    environment:
+      # Allow the default user to connect without a password
+      - CLICKHOUSE_SKIP_USER_SETUP=1
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -1,4 +1,17 @@
 services:
+  dbt-clickhouse:
+    image: clickhouse/clickhouse-server:latest
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    environment:
+      # Allow the default user to connect without a password
+      - CLICKHOUSE_SKIP_USER_SETUP=1
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+
   dbt-postgres:
     image: postgres:latest
     ports:
@@ -23,16 +36,3 @@ services:
     image: trinodb/trino:latest
     ports:
       - "8080:8080"
-
-  dbt-clickhouse:
-    image: clickhouse/clickhouse-server:latest
-    ports:
-      - "8123:8123"
-      - "9000:9000"
-    environment:
-      # Allow the default user to connect without a password
-      - CLICKHOUSE_SKIP_USER_SETUP=1
-    ulimits:
-      nofile:
-        soft: 262144
-        hard: 262144

--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -214,3 +214,11 @@
 {% macro spark__get_test_timestamps() -%}
     {{ return(["2021-06-07 07:35:20.000000", "2021-06-07 14:35:20.000000"]) }}
 {%- endmacro %}
+
+{% macro clickhouse__get_test_timestamps() -%}
+    {# ClickHouse can't CAST the default fixtures' timezone-NAME suffix
+       (e.g. 'America/Los_Angeles') to DateTime, not even with
+       cast_string_to_date_time_mode=best_effort, and the convert_timezone tests need
+       naive wall-clock values, so use plain timestamps here. #}
+    {{ return(["2021-06-07 07:35:20", "2021-06-07 14:35:20"]) }}
+{%- endmacro %}

--- a/integration_tests/profiles.yml
+++ b/integration_tests/profiles.yml
@@ -22,6 +22,16 @@ integration_tests:
       job_retries: 3
       location: US
 
+    clickhouse:
+      type: clickhouse
+      driver: http
+      host: "{{ env_var('CLICKHOUSE_HOST') }}"
+      port: "{{ env_var('CLICKHOUSE_PORT') | as_number }}"
+      user: "{{ env_var('CLICKHOUSE_USER') }}"
+      schema: "{{ env_var('CLICKHOUSE_SCHEMA') }}"
+      secure: false
+      threads: 5
+
     databricks:
       type: databricks
       catalog: "{{ env_var('DATABRICKS_CATALOG', 'hive_metastore') }}"
@@ -79,13 +89,3 @@ integration_tests:
       schema: "{{ env_var('TRINO_SCHEMA') }}"
       timezone: "{{ env_var('TRINO_TIMEZONE') }}"
       threads: 12
-
-    clickhouse:
-      type: clickhouse
-      driver: http
-      host: "{{ env_var('CLICKHOUSE_HOST') }}"
-      port: "{{ env_var('CLICKHOUSE_PORT') | as_number }}"
-      user: "{{ env_var('CLICKHOUSE_USER') }}"
-      schema: "{{ env_var('CLICKHOUSE_SCHEMA') }}"
-      secure: false
-      threads: 5

--- a/integration_tests/profiles.yml
+++ b/integration_tests/profiles.yml
@@ -79,3 +79,13 @@ integration_tests:
       schema: "{{ env_var('TRINO_SCHEMA') }}"
       timezone: "{{ env_var('TRINO_TIMEZONE') }}"
       threads: 12
+
+    clickhouse:
+      type: clickhouse
+      driver: http
+      host: "{{ env_var('CLICKHOUSE_HOST') }}"
+      port: "{{ env_var('CLICKHOUSE_PORT') | as_number }}"
+      user: "{{ env_var('CLICKHOUSE_USER') }}"
+      schema: "{{ env_var('CLICKHOUSE_SCHEMA') }}"
+      secure: false
+      threads: 5

--- a/macros/calendar_date/convert_timezone.sql
+++ b/macros/calendar_date/convert_timezone.sql
@@ -38,6 +38,23 @@
     )
 {%- endmacro -%}
 
+{# sqlfmt disabled below: ClickHouse function names are case-sensitive #}
+-- fmt: off
+{% macro clickhouse__convert_timezone(column, target_tz, source_tz) -%}
+    {#
+        ClickHouse DateTime is timezone-aware, so toTimeZone only changes the
+        displayed zone, not the instant. Round-tripping through a string drops the
+        zone and returns the target wall-clock as a naive DateTime, matching the
+        timezone-naive result the other adapters produce.
+    #}
+    toDateTime(
+        toString(
+            toTimeZone(toDateTime({{ column }}, '{{ source_tz }}'), '{{ target_tz }}')
+        )
+    )
+{%- endmacro -%}
+-- fmt: on
+
 {%- macro trino__convert_timezone(column, target_tz, source_tz) -%}
     cast(
         (

--- a/macros/calendar_date/date_part.sql
+++ b/macros/calendar_date/date_part.sql
@@ -13,3 +13,23 @@
 {% macro trino__date_part(datepart, date) -%}
     extract({{ datepart }} from {{ date }})
 {%- endmacro %}
+
+{# sqlfmt disabled below: ClickHouse function names are case-sensitive #}
+-- fmt: off
+{% macro clickhouse__date_part(datepart, date) -%}
+    {%- set datepart = datepart | lower -%}
+    {#
+        EXTRACT handles year/quarter/month/day/hour/minute/second/epoch. The rest need
+        ClickHouse functions: dayofweek/dayofyear/isoweek aren't valid EXTRACT units, and
+        EXTRACT(week) is ISO-numbered whereas week_of_year expects the non-ISO week.
+    #}
+    {%- if datepart in ["dayofweek", "dow"] -%}
+        {# Sunday = 0 ... Saturday = 6, matching the default__ macros' expectations #}
+        toDayOfWeek({{ date }}, 2)
+    {%- elif datepart in ["dayofyear", "doy"] -%} toDayOfYear({{ date }})
+    {%- elif datepart == "isoweek" -%} toISOWeek({{ date }})
+    {%- elif datepart == "week" -%} toWeek({{ date }}, 0)
+    {%- else -%} extract({{ datepart }} from {{ date }})
+    {%- endif -%}
+{%- endmacro %}
+-- fmt: on

--- a/macros/calendar_date/day_name.sql
+++ b/macros/calendar_date/day_name.sql
@@ -54,3 +54,15 @@
     {%- else -%} {{ dbt_date.day_name_localized(date, short, language) }}
     {%- endif -%}
 {%- endmacro -%}
+
+{# sqlfmt disabled below: ClickHouse function names are case-sensitive #}
+-- fmt: off
+{%- macro clickhouse__day_name(date, short, language) -%}
+    {%- if language == "default" -%}
+        {%- if short -%} formatDateTime({{ date }}, '%a')
+        {%- else -%} dateName('weekday', {{ date }})
+        {%- endif -%}
+    {%- else -%} {{ dbt_date.day_name_localized(date, short, language) }}
+    {%- endif -%}
+{%- endmacro -%}
+-- fmt: on

--- a/macros/calendar_date/from_unixtimestamp.sql
+++ b/macros/calendar_date/from_unixtimestamp.sql
@@ -108,3 +108,19 @@
     {% endif -%}
     cast(to_timestamp({{ epochs }}) at time zone 'UTC' as timestamp)
 {%- endmacro %}
+
+{# sqlfmt disabled below: ClickHouse function names are case-sensitive #}
+-- fmt: off
+{%- macro clickhouse__from_unixtimestamp(epochs, format="seconds") -%}
+    {%- if format != "seconds" -%}
+        {{
+            exceptions.raise_compiler_error(
+                "value "
+                ~ format
+                ~ " for `format` for from_unixtimestamp is not supported."
+            )
+        }}
+    {% endif -%}
+    fromUnixTimestamp({{ epochs }})
+{%- endmacro %}
+-- fmt: on

--- a/macros/calendar_date/iso_week_start.sql
+++ b/macros/calendar_date/iso_week_start.sql
@@ -30,3 +30,7 @@
 {%- macro trino__iso_week_start(date) -%}
     {{ dbt_date._iso_week_start(date, "week") }}
 {%- endmacro %}
+
+{%- macro clickhouse__iso_week_start(date) -%}
+    {{ dbt_date._iso_week_start(date, "week") }}
+{%- endmacro %}

--- a/macros/calendar_date/month_name.sql
+++ b/macros/calendar_date/month_name.sql
@@ -54,3 +54,15 @@
     {%- else -%} {{ dbt_date.month_name_localized(date, short, language) }}
     {%- endif -%}
 {%- endmacro %}
+
+{# sqlfmt disabled below: ClickHouse function names are case-sensitive #}
+-- fmt: off
+{%- macro clickhouse__month_name(date, short, language) -%}
+    {%- if language == "default" -%}
+        {%- if short -%} formatDateTime({{ date }}, '%b')
+        {%- else -%} dateName('month', {{ date }})
+        {%- endif -%}
+    {%- else -%} {{ dbt_date.month_name_localized(date, short, language) }}
+    {%- endif -%}
+{%- endmacro %}
+-- fmt: on

--- a/macros/calendar_date/week_end.sql
+++ b/macros/calendar_date/week_end.sql
@@ -16,3 +16,7 @@
 {%- macro duckdb__week_end(date) -%}
     {{ return(dbt_date.postgres__week_end(date)) }}
 {%- endmacro %}
+
+{%- macro clickhouse__week_end(date) -%}
+    {%- set dt = dbt_date.week_start(date) -%} {{ dbt_date.n_days_away(6, dt) }}
+{%- endmacro %}

--- a/macros/calendar_date/week_start.sql
+++ b/macros/calendar_date/week_start.sql
@@ -30,3 +30,10 @@
 {%- macro duckdb__week_start(date) -%}
     {{ return(dbt_date.postgres__week_start(date)) }}
 {%- endmacro %}
+
+{# sqlfmt disabled below: ClickHouse function names are case-sensitive #}
+-- fmt: off
+{%- macro clickhouse__week_start(date) -%}
+    cast(toStartOfWeek({{ date }}, 0) as date)
+{%- endmacro %}
+-- fmt: on

--- a/macros/fiscal_date/get_fiscal_year_dates.sql
+++ b/macros/fiscal_date/get_fiscal_year_dates.sql
@@ -89,12 +89,14 @@
         fiscal_year_dates as (
 
             select
-                d.date_day,
-                m.fiscal_year_number,
-                m.fiscal_year_start_date,
-                m.fiscal_year_end_date,
-                w.week_start_date,
-                w.week_end_date,
+                -- Explicit aliases needed for ClickHouse in this context 
+                -- as column names keep their source-table qualifier
+                d.date_day as date_day,
+                m.fiscal_year_number as fiscal_year_number,
+                m.fiscal_year_start_date as fiscal_year_start_date,
+                m.fiscal_year_end_date as fiscal_year_end_date,
+                w.week_start_date as week_start_date,
+                w.week_end_date as week_end_date,
                 -- we reset the weeks of the year starting with the merch year start
                 -- date
                 dense_rank() over (

--- a/supported_adapters.env
+++ b/supported_adapters.env
@@ -1,1 +1,1 @@
-SUPPORTED_ADAPTERS=bigquery,databricks,duckdb,postgres
+SUPPORTED_ADAPTERS=bigquery,clickhouse,databricks,duckdb,postgres

--- a/supported_adapters.env
+++ b/supported_adapters.env
@@ -1,1 +1,1 @@
-SUPPORTED_ADAPTERS=bigquery,clickhouse,databricks,duckdb,postgres
+SUPPORTED_ADAPTERS=bigquery,databricks,duckdb,postgres

--- a/supported_adapters.env
+++ b/supported_adapters.env
@@ -1,1 +1,1 @@
-SUPPORTED_ADAPTERS=bigquery,databricks,duckdb,postgres
+SUPPORTED_ADAPTERS=bigquery,databricks,duckdb

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,11 @@ passenv =
     BIGQUERY_PROJECT
     BIGQUERY_SCHEMA
 
+    CLICKHOUSE_HOST
+    CLICKHOUSE_PORT
+    CLICKHOUSE_SCHEMA
+    CLICKHOUSE_USER
+
     DBT_ENV_SECRET_DATABRICKS_TOKEN
     DATABRICKS_HTTP_PATH
     DATABRICKS_HOST
@@ -37,11 +42,6 @@ passenv =
     TRINO_TIMEZONE
     TRINO_USER
 
-    CLICKHOUSE_HOST
-    CLICKHOUSE_PORT
-    CLICKHOUSE_SCHEMA
-    CLICKHOUSE_USER
-
 [testenv:dbt_integration_bigquery]
 changedir = integration_tests
 allowlist_externals =
@@ -51,16 +51,6 @@ commands =
     dbt debug --target bigquery
     dbt deps
     dbt build --target bigquery --full-refresh # Single run as a new dataset is created for every run
-
-[testenv:dbt_integration_databricks]
-changedir = integration_tests
-allowlist_externals =
-    dbt
-skip_install = true
-commands =
-    dbt debug --target databricks
-    dbt deps
-    dbt build --target databricks --full-refresh # Single run as a new dataset is created for every run
 
 [testenv:dbt_integration_clickhouse]
 changedir = integration_tests
@@ -72,6 +62,16 @@ commands =
     dbt deps
     dbt run --target clickhouse
     dbt test --target clickhouse
+
+[testenv:dbt_integration_databricks]
+changedir = integration_tests
+allowlist_externals =
+    dbt
+skip_install = true
+commands =
+    dbt debug --target databricks
+    dbt deps
+    dbt build --target databricks --full-refresh # Single run as a new dataset is created for every run
 
 [testenv:dbt_integration_duckdb]
 changedir = integration_tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = testenv, dbt_integration_{bigquery,databricks,duckdb,postgres,spark,trino}, fusion_integration_{bigquery,databricks}
+envlist = testenv, dbt_integration_{bigquery,databricks,clickhouse,duckdb,postgres,spark,trino}, fusion_integration_{bigquery,databricks}
 
 [testenv]
 passenv =
@@ -37,6 +37,11 @@ passenv =
     TRINO_TIMEZONE
     TRINO_USER
 
+    CLICKHOUSE_HOST
+    CLICKHOUSE_PORT
+    CLICKHOUSE_SCHEMA
+    CLICKHOUSE_USER
+
 [testenv:dbt_integration_bigquery]
 changedir = integration_tests
 allowlist_externals =
@@ -56,6 +61,17 @@ commands =
     dbt debug --target databricks
     dbt deps
     dbt build --target databricks --full-refresh # Single run as a new dataset is created for every run
+
+[testenv:dbt_integration_clickhouse]
+changedir = integration_tests
+allowlist_externals =
+    dbt
+skip_install = true
+commands =
+    dbt debug --target clickhouse
+    dbt deps
+    dbt run --target clickhouse
+    dbt test --target clickhouse
 
 [testenv:dbt_integration_duckdb]
 changedir = integration_tests


### PR DESCRIPTION
Hi dbt-date team!

When we added ClickHouse support for dbt's Jaffle Shop, we needed to add a ClickHouse version of dbt-date's `convert_timezone` macro: https://github.com/ClickHouse/jaffle-shop-clickhouse/blob/e7c0a7ecf37ff3b46777149817289d94221845f8/macros/dbt_date_ch.sql. I spoke with @dataders about removing the fork and moving all the changes to their respective places. For this macro, one idea was to simply move this to the dbt-clickhouse adapter (https://github.com/ClickHouse/dbt-clickhouse/pull/646), but I started wondering: what if we added complete ClickHouse support to dbt-date instead? So here I am, opening this PR with the necessary changes :D

A few notes:
- CH versions < 26.5 cannot correctly parse the timezone-aware values, but it's possible if one specific setting is added. I have added a comment in the readme mentioning it. The testing is done with latest (26.5) which don't require it. We can add it to the `profile.yaml` so the tests can be executed against other CH versions if we want to do that.
- The changes in the SQL of `get_fiscal_year_dates.sql` are required because a know bug on the current ClickHouse SQL query analyser that should be fixed. Related issues: https://github.com/ClickHouse/ClickHouse/issues/87022 and https://github.com/ClickHouse/ClickHouse/issues/66133. The fix should be safe for other databases as in their case we are just renaming the column to the same name.

Let me know if I can help with something/any change. Thanks for checking the PR! :D 