### PR TITLE
Cascade secret-bearing CI via workflow_run so fork PRs stay green

### DIFF
--- a/.github/workflows/ci-multiple-dbt-versions-with-secrets.yml
+++ b/.github/workflows/ci-multiple-dbt-versions-with-secrets.yml
@@ -1,0 +1,188 @@
+name: Integration testing (secret-bearing adapters)
+
+# Triggered on workflow_run after "Integration testing (no-secret adapters)"
+# succeeds — runs in the base repo context so secrets are available, then
+# explicitly checks out the PR's head SHA and posts a commit status back so
+# the result shows up on the PR.
+#
+# Also runs on push to main and on workflow_dispatch for full coverage.
+#
+# Security model: this workflow's definition is always the base-branch copy
+# (PRs cannot rewrite it). The risk it accepts is executing fork PR code with
+# warehouse secrets in scope — the same tradeoff as pull_request_target.
+# First-time-contributor approval at the GitHub repo level gates the upstream
+# workflow run, so this workflow only cascades after a maintainer has cleared
+# the contributor at least once.
+
+on:
+  workflow_run:
+    workflows: ["Integration testing (no-secret adapters)"]
+    types: [completed]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  DBT_PROJECT_DIR: integration_tests
+  DBT_PROFILES_DIR: integration_tests
+  BIGQUERY_PROJECT: dbt-date
+  BIGQUERY_KEYFILE_JSON: ${{ secrets.BIGQUERY_KEYFILE_JSON }}
+  BIGQUERY_SCHEMA: "integration_tests_bigquery_${{ github.run_number }}"
+  DBT_ENV_SECRET_DATABRICKS_TOKEN: "${{ secrets.DBT_ENV_SECRET_DATABRICKS_TOKEN }}"
+  DATABRICKS_HTTP_PATH: "${{ vars.DATABRICKS_HTTP_PATH }}"
+  DATABRICKS_HOST: "${{ vars.DATABRICKS_HOST }}"
+  DATABRICKS_SCHEMA: "dbt_date_${{ github.run_number }}"
+
+jobs:
+  # Decide whether to actually run, and surface the ref/sha to use.
+  # For workflow_run: only proceed when the upstream concluded 'success'.
+  # For push / workflow_dispatch: always proceed using the triggering ref.
+  prepare:
+    runs-on: ubuntu-latest
+    # workflow_run cascades only when upstream came from a PR — on push to main
+    # the explicit push trigger below handles it, so we don't duplicate.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'pull_request')
+    permissions:
+      contents: read
+    outputs:
+      head_sha: ${{ steps.context.outputs.head_sha }}
+      is_pr: ${{ steps.context.outputs.is_pr }}
+    steps:
+      - id: context
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_run" ]]; then
+            echo "head_sha=$UPSTREAM_HEAD_SHA" >> "$GITHUB_OUTPUT"
+            echo "is_pr=$([[ "$UPSTREAM_EVENT" == "pull_request" ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          else
+            echo "head_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          UPSTREAM_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          UPSTREAM_EVENT: ${{ github.event.workflow_run.event }}
+
+  integration_tests:
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    strategy:
+      fail-fast: false
+      matrix:
+        adapter:
+          - bigquery
+          - databricks
+        dbt-version:
+          - "1.10"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.head_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+
+      - name: Install dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }}
+        run: pip install "dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }}.0" "dbt-core~=${{ matrix.dbt-version }}.0" tox
+
+      - name: Run integration tests (${{ matrix.adapter }})
+        run: |
+          export DBT_SUFFIX=_$(date +%6N)
+          tox -e dbt_integration_${{ matrix.adapter }}
+
+      - name: Report commit status
+        if: always() && github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
+          STATE: ${{ job.status == 'success' && 'success' || 'failure' }}
+          CONTEXT: integration_tests (${{ matrix.adapter }}, ${{ matrix.dbt-version }})
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f "state=${STATE}" \
+            -f "context=${CONTEXT}" \
+            -f "description=Cascaded after no-secret tests" \
+            -f "target_url=${RUN_URL}"
+
+  integration_tests_fusion:
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    strategy:
+      fail-fast: false
+      matrix:
+        adapter:
+          - bigquery
+          - databricks
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.head_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+
+      # Having a DuckDB adapter in profiles.yml is unsupported by Fusion (even if unused)
+      - name: Update profiles.yml
+        run: |
+          yq -i eval 'del .integration_tests.outputs.duckdb' ./integration_tests/profiles.yml
+          yq -i eval '.integration_tests.target = "bigquery"' ./integration_tests/profiles.yml
+
+      # Fusion for BigQuery requires a different auth method
+      - name: Save BigQuery key file as a file
+        if: ${{ matrix.adapter == 'bigquery' }}
+        env:
+          KEYFILE_B64: ${{ secrets.BIGQUERY_KEYFILE_JSON_BASE64 }}
+        run: |
+          printf '%s' "$KEYFILE_B64" | base64 --decode >> ./integration_tests/service-key-file.json
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Install dbt Fusion
+        run: |
+          curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Verify dbt installation
+        run: dbt --version
+
+      - name: Run fusion integration tests (${{ matrix.adapter }})
+        env:
+          BIGQUERY_KEYFILE_JSON: ${{ secrets.BIGQUERY_KEYFILE_JSON }}
+          BIGQUERY_PROJECT: ${{ env.BIGQUERY_PROJECT }}
+          BIGQUERY_SCHEMA: ${{ env.BIGQUERY_SCHEMA }}
+          DBT_ENV_SECRET_DATABRICKS_TOKEN: ${{ secrets.DBT_ENV_SECRET_DATABRICKS_TOKEN }}
+          DATABRICKS_HTTP_PATH: ${{ vars.DATABRICKS_HTTP_PATH }}
+          DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
+          DATABRICKS_SCHEMA: ${{ env.DATABRICKS_SCHEMA }}
+        run: |
+          export DBT_SUFFIX=_$(date +%6N)
+          tox -e fusion_integration_${{ matrix.adapter }}
+
+      - name: Report commit status
+        if: always() && github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
+          STATE: ${{ job.status == 'success' && 'success' || 'failure' }}
+          CONTEXT: integration_tests_fusion (${{ matrix.adapter }})
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f "state=${STATE}" \
+            -f "context=${CONTEXT}" \
+            -f "description=Cascaded after no-secret tests" \
+            -f "target_url=${RUN_URL}"

--- a/.github/workflows/ci-multiple-dbt-versions.yml
+++ b/.github/workflows/ci-multiple-dbt-versions.yml
@@ -1,4 +1,9 @@
-name: Integration testing (multiple dbt versions)
+name: Integration testing (no-secret adapters)
+
+# Triggered on every PR and push. Only runs adapters that need no GitHub
+# secrets (the docker-compose ones), so fork PRs work the same as same-repo
+# PRs. Secret-bearing adapters live in ci-multiple-dbt-versions-with-secrets.yml,
+# which is triggered via workflow_run after this workflow succeeds.
 
 on:
   push:
@@ -12,17 +17,10 @@ on:
 env:
   DBT_PROJECT_DIR: integration_tests
   DBT_PROFILES_DIR: integration_tests
-  BIGQUERY_PROJECT: dbt-date
-  BIGQUERY_KEYFILE_JSON: ${{ secrets.BIGQUERY_KEYFILE_JSON }}
-  BIGQUERY_SCHEMA: "integration_tests_bigquery_${{ github.run_number }}"
   CLICKHOUSE_HOST: localhost
   CLICKHOUSE_PORT: "8123"
   CLICKHOUSE_SCHEMA: dbt_date
   CLICKHOUSE_USER: default
-  DBT_ENV_SECRET_DATABRICKS_TOKEN: "${{ secrets.DBT_ENV_SECRET_DATABRICKS_TOKEN }}"
-  DATABRICKS_HTTP_PATH: "${{ vars.DATABRICKS_HTTP_PATH }}"
-  DATABRICKS_HOST: "${{ vars.DATABRICKS_HOST }}"
-  DATABRICKS_SCHEMA: "dbt_date_${{ github.run_number }}"
   DBT_ENV_SECRET_POSTGRES_PASS: dbt
   POSTGRES_DATABASE: metastore
   POSTGRES_HOST: localhost
@@ -42,6 +40,7 @@ env:
   TRINO_SCHEMA: dbt
   TRINO_TIMEZONE: UTC
   TRINO_USER: dbt
+
 jobs:
   integration_tests:
     runs-on: ubuntu-latest
@@ -51,9 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         adapter:
-          - bigquery
           - clickhouse
-          - databricks
           - duckdb
           - postgres
           - spark
@@ -72,11 +69,10 @@ jobs:
         run: pip install "dbt-${{ matrix.adapter }}[PyHive]~=${{ matrix.dbt-version }}.0" "dbt-core~=${{ matrix.dbt-version }}.0" tox
 
       - name: Install dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }}
-        if: ${{ matrix.adapter != 'spark' && !(matrix.adapter == 'bigquery' && matrix.dbt-version == '1.6') }}
+        if: ${{ matrix.adapter != 'spark' }}
         run: pip install "dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }}.0" "dbt-core~=${{ matrix.dbt-version }}.0" tox
 
       - name: Install testing dependencies (non-python)
-        if: ${{ matrix.adapter == 'clickhouse' || matrix.adapter == 'postgres' || matrix.adapter == 'spark' || matrix.adapter == 'trino' }}
         run: |
           docker compose -f ./integration_tests/docker-compose.yml up -d dbt-${{ matrix.adapter }}
           sleep 30
@@ -85,56 +81,3 @@ jobs:
         run: |
           export DBT_SUFFIX=_$(date +%6N)
           tox -e dbt_integration_${{ matrix.adapter }}
-
-  integration_tests_fusion:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        adapter:
-          - bigquery
-          - databricks
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-
-      # Having a DuckDB adapter in profiles.yml is unsupported by Fusion (even if unused)
-      - name: Update profiles.yml
-        run: |
-          yq -i eval 'del .integration_tests.outputs.duckdb' ./integration_tests/profiles.yml
-          yq -i eval '.integration_tests.target = "bigquery"' ./integration_tests/profiles.yml
-
-      # Fusion for BigQuery requires a different auth method
-      - name: Save BigQuery key file as a file
-        if: ${{ matrix.adapter == 'bigquery' }}
-        run: |
-          echo -n "${{ secrets.BIGQUERY_KEYFILE_JSON_BASE64 }}" | base64 --decode >> ./integration_tests/service-key-file.json
-
-      - name: Install tox
-        run: pip install tox
-
-      - name: Install dbt Fusion
-        run: |
-          curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Verify dbt installation
-        run: dbt --version
-
-      - name: Run fusion integration tests (${{ matrix.adapter }})
-        env:
-          BIGQUERY_KEYFILE_JSON: ${{ secrets.BIGQUERY_KEYFILE_JSON }}
-          BIGQUERY_PROJECT: ${{ env.BIGQUERY_PROJECT }}
-          BIGQUERY_SCHEMA: ${{ env.BIGQUERY_SCHEMA }}
-          DBT_ENV_SECRET_DATABRICKS_TOKEN: ${{ secrets.DBT_ENV_SECRET_DATABRICKS_TOKEN }}
-          DATABRICKS_HTTP_PATH: ${{ vars.DATABRICKS_HTTP_PATH }}
-          DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
-          DATABRICKS_SCHEMA: ${{ env.DATABRICKS_SCHEMA }}
-        run: |
-          export DBT_SUFFIX=_$(date +%6N)
-          tox -e fusion_integration_${{ matrix.adapter }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: Package Integration Tests
 
+# This calls the dbt-labs/dbt-package-testing reusable workflow, which does
+# not accept a checkout ref input — so it always tests the base branch.
+# Running it on pull_request would silently re-test main against the PR
+# author's credentials with no benefit, so we only run it on push to main
+# (post-merge coverage) and on manual dispatch.
+
 on:
   push:
-    branches:
-      - main
-  pull_request:
     branches:
       - main
   workflow_dispatch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,10 +82,11 @@ Do **not** use `{{ modules.datetime... }}` for this — the dbt-fusion Jinja eng
 
 ## CI
 
-Two workflows in `.github/workflows/`:
+Three workflows in `.github/workflows/`:
 
-- `ci.yml` — delegates to `dbt-labs/dbt-package-testing` reusable workflow for BigQuery, Databricks, Postgres, Trino.
-- `ci-multiple-dbt-versions.yml` — matrix over `{bigquery, databricks, duckdb, postgres, spark, trino} x {1.10}` plus a Fusion engine job for BigQuery and Databricks.
+- `ci-multiple-dbt-versions.yml` — runs the no-secret adapters (`clickhouse, duckdb, postgres, spark, trino`) on every PR and push. Works the same for fork PRs and same-repo branches because nothing here needs GitHub secrets.
+- `ci-multiple-dbt-versions-with-secrets.yml` — runs the secret-bearing adapters (`bigquery, databricks`) plus the Fusion engine job. Triggered via `workflow_run` after the no-secret workflow succeeds, plus on push to main. Runs in base-repo context so secrets are available; explicitly checks out the PR's head SHA and posts a commit status back to it.
+- `ci.yml` — delegates to `dbt-labs/dbt-package-testing` reusable workflow. Runs on push to main only (the reusable workflow can't be steered at a non-base ref, so running it on PRs would silently re-test main).
 
 After pushing, monitor with `gh run list --branch <branch> --limit 5`. If a PR has merge conflicts CI won't trigger — rebase onto `main` first.
 


### PR DESCRIPTION
Drafting this because the security model deserves your eyes — please read the trade-off section before approving.

Splits `ci-multiple-dbt-versions.yml` into a no-secret half (`pull_request` + `push: main`) and a secret-bearing half (`workflow_run` after the first succeeds + direct `push: main`). The no-secret half runs the same way on fork PRs and same-repo PRs; the secret-bearing half cascades automatically once the no-secret half goes green and posts a commit status back to the PR head so the result is visible on the Checks tab.

Also drops `pull_request` from `ci.yml` — the `dbt-labs/dbt-package-testing` reusable workflow doesn't accept a checkout ref, so running it on PRs silently re-tests `main` against the PR author's credentials with no benefit. Restricted to `push: main` and `workflow_dispatch`.

## Security trade-off

The new `with-secrets` workflow's definition is always loaded from the base branch — a PR can't rewrite the workflow itself. But it does explicitly check out `${{ github.event.workflow_run.head_sha }}` and run that code with warehouse secrets in scope. This is the same risk as `pull_request_target`, just spelled differently. The first-time-contributor approval at the repo level still gates whether the upstream workflow runs at all, so the cascade can't fire for a contributor a maintainer hasn't cleared.

## Manual verification needed

The `workflow_run` mechanics and commit-status posting are easy to typo in ways that only show up at runtime. Plan:

- [ ] Confirm the no-secret workflow runs cleanly on this PR (same-repo branch).
- [ ] Verify the cascade triggers and posts statuses by opening a small follow-up PR from a fork.
- [ ] Sanity-check that `push: main` does not double-fire the secret workflow (the `prepare` job's `if:` is meant to suppress the cascade copy when upstream was a push).

## Out of scope

- The "remove postgres because dbt-postgres pulls Fusion via a transitive pre-release dep" workaround stays in place. A separate follow-up should file an upstream issue at `dbt-labs/dbt-package-testing`.
