### PR TITLE
Schedule a daily CI run on main

### DIFF
--- a/.github/workflows/ci-multiple-dbt-versions.yml
+++ b/.github/workflows/ci-multiple-dbt-versions.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - main
+  # Daily run against main so we catch upstream drift (action versions,
+  # dbt-adapter releases, dependency resolution flips) before the next PR does.
+  # 05:17 UTC is off-peak for shared GitHub runners.
+  schedule:
+    - cron: "17 5 * * *"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - main
+  # Daily run against main so we catch upstream drift in the reusable
+  # workflow (e.g. tag retags, runner image bumps, transitive dep flips).
+  # Offset 17 minutes after the no-secret workflow's scheduled run.
+  schedule:
+    - cron: "34 5 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds a daily `schedule: cron` trigger to both integration test workflows so upstream drift gets caught by CI on a quiet morning rather than by the next contributor's PR.

Concrete drift scenarios this catches:

- `pip install dbt-<adapter>` resolving to a newer dbt-core that breaks parsing or installation (exactly the cascade that took out PR #56 — `dbt-postgres==1.10.0`'s `dbt-core>=1.8.0rc1` lower bound silently pulled in Fusion alpha).
- `dbt-labs/dbt-package-testing@v1` being re-tagged onto a commit with different install semantics.
- `actions/checkout` / `actions/setup-python` moving the latest tag.
- `ubuntu-latest` base image bumping a system dependency.

Cron times:
- `ci-multiple-dbt-versions.yml`: 05:17 UTC
- `ci.yml`: 05:34 UTC

Both off-peak on shared GitHub runners. Offset between the two so they don't simultaneously pull the same docker images.

No code change beyond the two trigger blocks. Scheduled runs only fire against the default branch.
