### PR TITLE
Add dbt 1.11 to CI matrix for BigQuery and Databricks

### DIFF
--- a/.github/workflows/ci-multiple-dbt-versions.yml
+++ b/.github/workflows/ci-multiple-dbt-versions.yml
@@ -60,6 +60,13 @@ jobs:
           - trino
         dbt-version:
           - "1.10"
+        # Only BigQuery, Databricks, and dbt-core have a 1.11 stable on PyPI
+        # as of this PR. Add other adapters to this include list as they ship.
+        include:
+          - adapter: bigquery
+            dbt-version: "1.11"
+          - adapter: databricks
+            dbt-version: "1.11"
 
     steps:
       - uses: actions/checkout@v4

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
-dbt-bigquery>=1.10.0,<1.11.0
+dbt-bigquery>=1.10.0,<1.12.0
 dbt-clickhouse>=1.10.0,<1.11.0
-dbt-core>=1.10.5,<1.11.0
-dbt-databricks>=1.10.0,<1.11.0
+dbt-core>=1.10.5,<1.12.0
+dbt-databricks>=1.10.0,<1.12.0
 dbt-duckdb>=1.9.0,<1.11.0
 dbt-postgres>=1.9.0,<1.11.0
 dbt-spark[PyHive]>=1.9.0,<1.11.0


### PR DESCRIPTION
Adds dbt 1.11 coverage to CI for the adapters where it's available, and loosens `dev-requirements.txt` upper bounds correspondingly.

PyPI state today:

| Package | 1.11 latest |
|---|---|
| dbt-core | 1.11.9 |
| dbt-bigquery | 1.11.1 |
| dbt-databricks | 1.11.8 |
| dbt-clickhouse | not yet |
| dbt-duckdb | not yet |
| dbt-postgres | not yet |
| dbt-spark | not yet |
| dbt-trino | not yet |

So the matrix gets two `include:` entries (bigquery+1.11, databricks+1.11) on top of the existing 1.10-only row. Adapters without a 1.11 wheel stay on 1.10.

`dev-requirements.txt` upper bounds bumped to `<1.12.0` for the three packages that have 1.11; the rest stay at `<1.11.0` because pip would resolve dbt-core back to 1.10.x to satisfy them anyway and the bumped bound would be misleading.

`require-dbt-version` in `integration_tests/dbt_project.yml` already allows up to 3.x, nothing to change.

If/when an adapter ships 1.11, add it to the `include:` list and bump its `dev-requirements.txt` upper bound in the same commit.
