### PR TITLE
Replace fixed sleep with per-service readiness probes

### DIFF
--- a/.github/workflows/ci-multiple-dbt-versions.yml
+++ b/.github/workflows/ci-multiple-dbt-versions.yml
@@ -82,9 +82,34 @@ jobs:
 
       - name: Install testing dependencies (non-python)
         if: ${{ matrix.adapter == 'clickhouse' || matrix.adapter == 'postgres' || matrix.adapter == 'spark' || matrix.adapter == 'trino' }}
+        env:
+          ADAPTER: ${{ matrix.adapter }}
+          COMPOSE_FILE: ./integration_tests/docker-compose.yml
         run: |
-          docker compose -f ./integration_tests/docker-compose.yml up -d dbt-${{ matrix.adapter }}
-          sleep 30
+          docker compose -f "$COMPOSE_FILE" up -d "dbt-$ADAPTER"
+          # Wait until the service answers a real readiness probe rather than
+          # a fixed sleep — fails fast when a service is broken, returns sooner
+          # when it's healthy, and tells us which service didn't come up.
+          case "$ADAPTER" in
+            clickhouse)
+              probe='curl -sf http://localhost:8123/ping >/dev/null'
+              ;;
+            postgres)
+              probe='docker compose -f "$COMPOSE_FILE" exec -T dbt-postgres pg_isready -U dbt -d metastore'
+              ;;
+            trino)
+              probe='curl -sf http://localhost:8080/v1/info >/dev/null'
+              ;;
+            spark)
+              probe='nc -z localhost 10000'
+              ;;
+          esac
+          timeout 90 bash -c "until $probe; do sleep 2; done" || {
+            echo "::error::dbt-$ADAPTER did not become ready within 90s"
+            docker compose -f "$COMPOSE_FILE" logs "dbt-$ADAPTER"
+            exit 1
+          }
+          echo "dbt-$ADAPTER is ready"
 
       - name: Run integration tests (${{ matrix.adapter }})
         run: |

--- a/.github/workflows/ci-multiple-dbt-versions.yml
+++ b/.github/workflows/ci-multiple-dbt-versions.yml
@@ -87,28 +87,39 @@ jobs:
           COMPOSE_FILE: ./integration_tests/docker-compose.yml
         run: |
           docker compose -f "$COMPOSE_FILE" up -d "dbt-$ADAPTER"
-          # Wait until the service answers a real readiness probe rather than
-          # a fixed sleep — fails fast when a service is broken, returns sooner
-          # when it's healthy, and tells us which service didn't come up.
+          # Each adapter answers a real readiness probe rather than waiting a
+          # fixed amount of time — fails fast when a service is broken,
+          # returns sooner when it's healthy, and tells us which service
+          # didn't come up.
           case "$ADAPTER" in
             clickhouse)
-              probe='curl -sf http://localhost:8123/ping >/dev/null'
+              probe() { curl -sf http://localhost:8123/ping >/dev/null; }
               ;;
             postgres)
-              probe='docker compose -f "$COMPOSE_FILE" exec -T dbt-postgres pg_isready -U dbt -d metastore'
+              probe() { docker compose -f "$COMPOSE_FILE" exec -T dbt-postgres pg_isready -U dbt -d metastore; }
               ;;
             trino)
-              probe='curl -sf http://localhost:8080/v1/info >/dev/null'
+              # /v1/info returns 200 while the coordinator is still in
+              # "starting":true — only proceed once starting flips to false,
+              # otherwise dbt connects and gets SERVER_STARTING_UP.
+              probe() { curl -sf http://localhost:8080/v1/info | grep -q '"starting":false'; }
               ;;
             spark)
-              probe='nc -z localhost 10000'
+              # The thrift port binds before HiveServer2 can actually accept
+              # queries, so a TCP probe returns ready too early. Wait for the
+              # readiness log line instead.
+              probe() { docker compose -f "$COMPOSE_FILE" logs dbt-spark 2>&1 | grep -q "HiveThriftServer2 started"; }
               ;;
           esac
-          timeout 90 bash -c "until $probe; do sleep 2; done" || {
-            echo "::error::dbt-$ADAPTER did not become ready within 90s"
-            docker compose -f "$COMPOSE_FILE" logs "dbt-$ADAPTER"
-            exit 1
-          }
+          deadline=$(( $(date +%s) + 90 ))
+          until probe; do
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::dbt-$ADAPTER did not become ready within 90s"
+              docker compose -f "$COMPOSE_FILE" logs "dbt-$ADAPTER"
+              exit 1
+            fi
+            sleep 2
+          done
           echo "dbt-$ADAPTER is ready"
 
       - name: Run integration tests (${{ matrix.adapter }})


### PR DESCRIPTION
Replaces the fixed `sleep 30` after `docker compose up` with per-service readiness probes capped at 90s, plus a log dump on timeout.

Probes:

| Adapter | Probe |
|---|---|
| clickhouse | `curl -sf http://localhost:8123/ping` |
| postgres | `pg_isready -U dbt -d metastore` via `docker compose exec` |
| trino | `curl -sf http://localhost:8080/v1/info` |
| spark | `nc -z localhost 10000` |

Wins:

- A healthy service moves on as soon as it's actually ready (~2-8s for postgres/clickhouse instead of 30s) — faster CI on the common path.
- A sick service surfaces immediately with the container's logs in the job output instead of with a misleading `connection refused` from `dbt debug` 30s later.
- The 90s cap is 3× the old fixed wait, so service slowness isn't blocking either.

Matrix value routed through `env: ADAPTER:` per the repo's workflow-security pattern (no direct `${{ ... }}` interpolation inside `run:` scripts).
