### PR TITLE
Use .python-version as the source of truth for CI's Python version

### DIFF
--- a/.github/workflows/ci-multiple-dbt-versions.yml
+++ b/.github/workflows/ci-multiple-dbt-versions.yml
@@ -78,6 +78,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
 
       - name: Install dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }} (including Spark extra)
         if: ${{ matrix.adapter == 'spark' }}
@@ -114,6 +116,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
 
       # Having a DuckDB adapter in profiles.yml is unsupported by Fusion (even if unused)
       - name: Update profiles.yml


### PR DESCRIPTION
Wires `.python-version` into the CI workflow.

`actions/setup-python@v5` doesn't auto-discover `.python-version` — without `with: python-version:` or `with: python-version-file:` it picks the highest Python in the runner image's toolcache, which drifts silently when GitHub bumps the image.

Adds `python-version-file: .python-version` to both `setup-python` steps in `ci-multiple-dbt-versions.yml`, making the existing `.python-version` (currently `3.11.11`) the shared source of truth for local dev and CI. To bump Python going forward, change that one file.

Two lines of effective change.
