### PR TITLE
Trigger secret-bearing CI via /ok-to-test comment

### DIFF
--- a/.github/workflows/ci-multiple-dbt-versions.yml
+++ b/.github/workflows/ci-multiple-dbt-versions.yml
@@ -1,4 +1,10 @@
-name: Integration testing (multiple dbt versions)
+name: Integration testing (no-secret adapters)
+
+# Runs on every PR and push. Only covers adapters that need no GitHub
+# secrets (the docker-compose-backed ones plus duckdb), so fork PRs work
+# the same as same-repo PRs. Secret-bearing adapters live in
+# ci-secret-adapters.yml and are triggered by a maintainer commenting
+# `/ok-to-test <sha>` on the PR.
 
 on:
   push:
@@ -17,17 +23,10 @@ on:
 env:
   DBT_PROJECT_DIR: integration_tests
   DBT_PROFILES_DIR: integration_tests
-  BIGQUERY_PROJECT: dbt-date
-  BIGQUERY_KEYFILE_JSON: ${{ secrets.BIGQUERY_KEYFILE_JSON }}
-  BIGQUERY_SCHEMA: "integration_tests_bigquery_${{ github.run_number }}"
   CLICKHOUSE_HOST: localhost
   CLICKHOUSE_PORT: "8123"
   CLICKHOUSE_SCHEMA: dbt_date
   CLICKHOUSE_USER: default
-  DBT_ENV_SECRET_DATABRICKS_TOKEN: "${{ secrets.DBT_ENV_SECRET_DATABRICKS_TOKEN }}"
-  DATABRICKS_HTTP_PATH: "${{ vars.DATABRICKS_HTTP_PATH }}"
-  DATABRICKS_HOST: "${{ vars.DATABRICKS_HOST }}"
-  DATABRICKS_SCHEMA: "dbt_date_${{ github.run_number }}"
   DBT_ENV_SECRET_POSTGRES_PASS: dbt
   POSTGRES_DATABASE: metastore
   POSTGRES_HOST: localhost
@@ -47,6 +46,7 @@ env:
   TRINO_SCHEMA: dbt
   TRINO_TIMEZONE: UTC
   TRINO_USER: dbt
+
 jobs:
   integration_tests:
     runs-on: ubuntu-latest
@@ -56,22 +56,13 @@ jobs:
       fail-fast: false
       matrix:
         adapter:
-          - bigquery
           - clickhouse
-          - databricks
           - duckdb
           - postgres
           - spark
           - trino
         dbt-version:
           - "1.10"
-        # Only BigQuery, Databricks, and dbt-core have a 1.11 stable on PyPI
-        # as of this PR. Add other adapters to this include list as they ship.
-        include:
-          - adapter: bigquery
-            dbt-version: "1.11"
-          - adapter: databricks
-            dbt-version: "1.11"
 
     steps:
       - uses: actions/checkout@v4
@@ -86,7 +77,7 @@ jobs:
         run: pip install "dbt-${{ matrix.adapter }}[PyHive]~=${{ matrix.dbt-version }}.0" "dbt-core~=${{ matrix.dbt-version }}.0" tox
 
       - name: Install dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }}
-        if: ${{ matrix.adapter != 'spark' && !(matrix.adapter == 'bigquery' && matrix.dbt-version == '1.6') }}
+        if: ${{ matrix.adapter != 'spark' }}
         run: pip install "dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }}.0" "dbt-core~=${{ matrix.dbt-version }}.0" tox
 
       - name: Install testing dependencies (non-python)
@@ -135,58 +126,3 @@ jobs:
         run: |
           export DBT_SUFFIX=_$(date +%6N)
           tox -e dbt_integration_${{ matrix.adapter }}
-
-  integration_tests_fusion:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        adapter:
-          - bigquery
-          - databricks
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: .python-version
-
-      # Having a DuckDB adapter in profiles.yml is unsupported by Fusion (even if unused)
-      - name: Update profiles.yml
-        run: |
-          yq -i eval 'del .integration_tests.outputs.duckdb' ./integration_tests/profiles.yml
-          yq -i eval '.integration_tests.target = "bigquery"' ./integration_tests/profiles.yml
-
-      # Fusion for BigQuery requires a different auth method
-      - name: Save BigQuery key file as a file
-        if: ${{ matrix.adapter == 'bigquery' }}
-        run: |
-          echo -n "${{ secrets.BIGQUERY_KEYFILE_JSON_BASE64 }}" | base64 --decode >> ./integration_tests/service-key-file.json
-
-      - name: Install tox
-        run: pip install tox
-
-      - name: Install dbt Fusion
-        run: |
-          curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Verify dbt installation
-        run: dbt --version
-
-      - name: Run fusion integration tests (${{ matrix.adapter }})
-        env:
-          BIGQUERY_KEYFILE_JSON: ${{ secrets.BIGQUERY_KEYFILE_JSON }}
-          BIGQUERY_PROJECT: ${{ env.BIGQUERY_PROJECT }}
-          BIGQUERY_SCHEMA: ${{ env.BIGQUERY_SCHEMA }}
-          DBT_ENV_SECRET_DATABRICKS_TOKEN: ${{ secrets.DBT_ENV_SECRET_DATABRICKS_TOKEN }}
-          DATABRICKS_HTTP_PATH: ${{ vars.DATABRICKS_HTTP_PATH }}
-          DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
-          DATABRICKS_SCHEMA: ${{ env.DATABRICKS_SCHEMA }}
-        run: |
-          export DBT_SUFFIX=_$(date +%6N)
-          tox -e fusion_integration_${{ matrix.adapter }}

--- a/.github/workflows/ci-secret-adapters.yml
+++ b/.github/workflows/ci-secret-adapters.yml
@@ -163,6 +163,14 @@ jobs:
             dbt-version: "1.11"
 
     steps:
+      # CodeQL flags this checkout as "untrusted code in privileged context".
+      # Accurate description of the pattern — accepted trade-off, mitigated by
+      # (1) the `write+` ACL on `/ok-to-test` enforced in the `authorize` job,
+      # (2) the SHA being named explicitly in the maintainer's comment and
+      # re-verified against the PR's commit history before it reaches here, and
+      # (3) the SHA being regex-validated as 40-char hex before being passed to
+      # `ref:`. See the security model comment at the top of this file.
+      # codeql[actions/untrusted-checkout/high]
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.authorize.outputs.head_sha }}
@@ -210,6 +218,11 @@ jobs:
           - databricks
 
     steps:
+      # See the rationale comment on the matching checkout in `integration_tests`
+      # above. Same mitigations apply: `write+` ACL on `/ok-to-test`, explicit
+      # maintainer-named SHA verified against the PR's commit history, and
+      # 40-char hex validation before `ref:`.
+      # codeql[actions/untrusted-checkout/critical]
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.authorize.outputs.head_sha }}

--- a/.github/workflows/ci-secret-adapters.yml
+++ b/.github/workflows/ci-secret-adapters.yml
@@ -1,9 +1,9 @@
 name: Integration testing (secret-bearing adapters)
 
 # Triggered by:
-# - `/ok-to-test` comment from a write+ collaborator on a PR — runs against
-#   the PR's head SHA and posts commit statuses back so results show on the
-#   PR's Checks tab.
+# - `/ok-to-test <40-char-sha>` comment from a write+ collaborator on a PR
+#   — runs against the SHA named in the comment and posts commit statuses
+#   back so results show on the PR's Checks tab.
 # - push to main, scheduled run, manual dispatch — runs against the
 #   triggering ref directly.
 #
@@ -12,9 +12,13 @@ name: Integration testing (secret-bearing adapters)
 #
 # Security model: this workflow's definition is always the base-branch copy
 # (PRs cannot rewrite it). It does execute fork PR code with warehouse
-# secrets in scope — equivalent to `pull_request_target`. The
-# write-collaborator ACL on `/ok-to-test` is the gate; the head SHA is
-# validated to be a 40-char hex string before it's used as a checkout ref.
+# secrets in scope — equivalent to `pull_request_target`. Two gates:
+#   1. Write-collaborator ACL on `/ok-to-test`.
+#   2. The SHA to run is named explicitly in the comment, so a fork pushing
+#      a new commit between comment and workflow start cannot have its new
+#      commit run with secrets — only the SHA the maintainer reviewed and
+#      typed gets executed. The SHA must be reachable from the PR's head at
+#      the time the workflow runs (force-pushed-away SHAs are rejected).
 
 on:
   issue_comment:
@@ -81,9 +85,38 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           if [[ "$GITHUB_EVENT_NAME" == "issue_comment" ]]; then
-            head_sha=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')
+            # Parse `/ok-to-test <sha>` from the first line of the comment.
+            # Anything else is treated as a no-op so trailing prose is fine,
+            # but the SHA must be present, full-length (40 hex), and named
+            # explicitly by the maintainer — never resolved live from the
+            # PR head, otherwise a fork could push between comment and
+            # workflow start and have its new commit run with secrets.
+            first_line=$(printf '%s\n' "$COMMENT_BODY" | head -n 1)
+            read -r _cmd arg _rest <<<"$first_line"
+            if [[ ! "${arg}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::/ok-to-test requires a 40-char hex SHA. Usage: /ok-to-test <sha>"
+              gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                -f "body=:warning: \`/ok-to-test\` needs the full 40-char head SHA, e.g. \`/ok-to-test $(git rev-parse HEAD)\`. This guarantees the workflow runs exactly the code you reviewed." \
+                || true
+              exit 1
+            fi
+            # Confirm the named SHA is reachable from the PR's current head.
+            # This rejects (a) SHAs from other PRs and (b) SHAs that have
+            # been force-pushed away. It still allows ancestor SHAs from
+            # the PR's own history, which is the intended behaviour: the
+            # maintainer reviewed that specific commit.
+            current_head=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')
+            if ! gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" --jq '.[].sha' | grep -qFx "${arg}"; then
+              echo "::error::SHA ${arg} is not reachable from PR #${PR_NUMBER} head (${current_head})."
+              gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                -f "body=:warning: \`${arg}\` is not part of this PR's commit history. Current head is \`${current_head}\` — retry \`/ok-to-test ${current_head}\` if that's what you meant." \
+                || true
+              exit 1
+            fi
+            head_sha="${arg}"
           else
             head_sha="$GITHUB_SHA"
           fi

--- a/.github/workflows/ci-secret-adapters.yml
+++ b/.github/workflows/ci-secret-adapters.yml
@@ -1,0 +1,241 @@
+name: Integration testing (secret-bearing adapters)
+
+# Triggered by:
+# - `/ok-to-test` comment from a write+ collaborator on a PR — runs against
+#   the PR's head SHA and posts commit statuses back so results show on the
+#   PR's Checks tab.
+# - push to main, scheduled run, manual dispatch — runs against the
+#   triggering ref directly.
+#
+# Each new push to a fork PR requires a fresh `/ok-to-test` comment from a
+# maintainer; there is no sticky approval.
+#
+# Security model: this workflow's definition is always the base-branch copy
+# (PRs cannot rewrite it). It does execute fork PR code with warehouse
+# secrets in scope — equivalent to `pull_request_target`. The
+# write-collaborator ACL on `/ok-to-test` is the gate; the head SHA is
+# validated to be a 40-char hex string before it's used as a checkout ref.
+
+on:
+  issue_comment:
+    types: [created]
+  push:
+    branches:
+      - main
+  # Daily run against main so we catch upstream drift in the secret-bearing
+  # adapters too. Offset 30 minutes after the no-secret workflow.
+  schedule:
+    - cron: "47 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  # Cancel earlier runs for the same PR or main-branch ref. issue.number is
+  # blank for non-comment events, so push/schedule/dispatch group by sha.
+  group: secret-adapters-${{ github.event.issue.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  DBT_PROJECT_DIR: integration_tests
+  DBT_PROFILES_DIR: integration_tests
+  BIGQUERY_PROJECT: dbt-date
+  BIGQUERY_KEYFILE_JSON: ${{ secrets.BIGQUERY_KEYFILE_JSON }}
+  BIGQUERY_SCHEMA: "integration_tests_bigquery_${{ github.run_number }}"
+  DBT_ENV_SECRET_DATABRICKS_TOKEN: "${{ secrets.DBT_ENV_SECRET_DATABRICKS_TOKEN }}"
+  DATABRICKS_HTTP_PATH: "${{ vars.DATABRICKS_HTTP_PATH }}"
+  DATABRICKS_HOST: "${{ vars.DATABRICKS_HOST }}"
+  DATABRICKS_SCHEMA: "dbt_date_${{ github.run_number }}"
+
+jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    # Filter at the trigger boundary: only the `/ok-to-test` comment shape on
+    # a PR proceeds; all non-comment triggers (push/schedule/dispatch) fall
+    # through to the permission check, which short-circuits for them.
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/ok-to-test'))
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      head_sha: ${{ steps.context.outputs.head_sha }}
+    steps:
+      - name: Authorize commenter
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          permission=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${ACTOR}/permission" --jq '.permission')
+          echo "Commenter ${ACTOR} has permission: ${permission}"
+          case "${permission}" in
+            admin|maintain|write) ;;
+            *)
+              echo "::error::User ${ACTOR} (${permission}) is not authorised to trigger secret-bearing CI."
+              exit 1
+              ;;
+          esac
+
+      - id: context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "issue_comment" ]]; then
+            head_sha=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')
+          else
+            head_sha="$GITHUB_SHA"
+          fi
+          # Defence in depth: ensure the value going into `ref:` is a plain
+          # 40-char hex SHA, not anything that could be interpreted as a flag
+          # or path by downstream actions.
+          if [[ ! "${head_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Refusing to use head_sha=${head_sha}; expected 40-char hex."
+            exit 1
+          fi
+          echo "head_sha=${head_sha}" >> "$GITHUB_OUTPUT"
+          echo "Resolved head_sha=${head_sha}"
+
+      - name: Acknowledge comment
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEAD_SHA: ${{ steps.context.outputs.head_sha }}
+        run: |
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            -f "body=Secret-bearing integration tests started against \`${HEAD_SHA}\`: ${RUN_URL}"
+
+  integration_tests:
+    needs: [authorize]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    strategy:
+      fail-fast: false
+      matrix:
+        adapter:
+          - bigquery
+          - databricks
+        dbt-version:
+          - "1.10"
+        include:
+          - adapter: bigquery
+            dbt-version: "1.11"
+          - adapter: databricks
+            dbt-version: "1.11"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Install dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }}
+        run: pip install "dbt-${{ matrix.adapter }}~=${{ matrix.dbt-version }}.0" "dbt-core~=${{ matrix.dbt-version }}.0" tox
+
+      - name: Run integration tests (${{ matrix.adapter }})
+        run: |
+          export DBT_SUFFIX=_$(date +%6N)
+          tox -e dbt_integration_${{ matrix.adapter }}
+
+      - name: Report commit status
+        if: always() && github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          STATE: ${{ job.status == 'success' && 'success' || 'failure' }}
+          CONTEXT: integration_tests (${{ matrix.adapter }}, ${{ matrix.dbt-version }})
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f "state=${STATE}" \
+            -f "context=${CONTEXT}" \
+            -f "description=Triggered by /ok-to-test" \
+            -f "target_url=${RUN_URL}"
+
+  integration_tests_fusion:
+    needs: [authorize]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    strategy:
+      fail-fast: false
+      matrix:
+        adapter:
+          - bigquery
+          - databricks
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      # Having a DuckDB adapter in profiles.yml is unsupported by Fusion (even if unused)
+      - name: Update profiles.yml
+        run: |
+          yq -i eval 'del .integration_tests.outputs.duckdb' ./integration_tests/profiles.yml
+          yq -i eval '.integration_tests.target = "bigquery"' ./integration_tests/profiles.yml
+
+      # Fusion for BigQuery requires a different auth method
+      - name: Save BigQuery key file as a file
+        if: ${{ matrix.adapter == 'bigquery' }}
+        env:
+          KEYFILE_B64: ${{ secrets.BIGQUERY_KEYFILE_JSON_BASE64 }}
+        run: |
+          printf '%s' "$KEYFILE_B64" | base64 --decode >> ./integration_tests/service-key-file.json
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Install dbt Fusion
+        run: |
+          curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Verify dbt installation
+        run: dbt --version
+
+      - name: Run fusion integration tests (${{ matrix.adapter }})
+        env:
+          BIGQUERY_KEYFILE_JSON: ${{ secrets.BIGQUERY_KEYFILE_JSON }}
+          BIGQUERY_PROJECT: ${{ env.BIGQUERY_PROJECT }}
+          BIGQUERY_SCHEMA: ${{ env.BIGQUERY_SCHEMA }}
+          DBT_ENV_SECRET_DATABRICKS_TOKEN: ${{ secrets.DBT_ENV_SECRET_DATABRICKS_TOKEN }}
+          DATABRICKS_HTTP_PATH: ${{ vars.DATABRICKS_HTTP_PATH }}
+          DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
+          DATABRICKS_SCHEMA: ${{ env.DATABRICKS_SCHEMA }}
+        run: |
+          export DBT_SUFFIX=_$(date +%6N)
+          tox -e fusion_integration_${{ matrix.adapter }}
+
+      - name: Report commit status
+        if: always() && github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          STATE: ${{ job.status == 'success' && 'success' || 'failure' }}
+          CONTEXT: integration_tests_fusion (${{ matrix.adapter }})
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f "state=${STATE}" \
+            -f "context=${CONTEXT}" \
+            -f "description=Triggered by /ok-to-test" \
+            -f "target_url=${RUN_URL}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: Package Integration Tests
 
+# This calls the dbt-labs/dbt-package-testing reusable workflow, which does
+# not accept a checkout ref input — so it always tests the base branch.
+# Running it on pull_request would silently re-test main against the PR
+# author's credentials with no benefit, so we restrict to push: main
+# (post-merge coverage), the daily drift run, and manual dispatch.
+
 on:
   push:
-    branches:
-      - main
-  pull_request:
     branches:
       - main
   # Daily run against main so we catch upstream drift in the reusable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,10 @@
 name: Package Integration Tests
 
-# This calls the dbt-labs/dbt-package-testing reusable workflow, which does
-# not accept a checkout ref input — so it always tests the base branch.
-# Running it on pull_request would silently re-test main against the PR
-# author's credentials with no benefit, so we restrict to push: main
-# (post-merge coverage), the daily drift run, and manual dispatch.
-
 on:
   push:
+    branches:
+      - main
+  pull_request:
     branches:
       - main
   # Daily run against main so we catch upstream drift in the reusable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Three workflows in `.github/workflows/`:
 
 - `ci-multiple-dbt-versions.yml` — runs the no-secret adapters (`clickhouse, duckdb, postgres, spark, trino`) on every PR and push. Works the same for fork PRs and same-repo branches because nothing here needs GitHub secrets.
 - `ci-secret-adapters.yml` — runs the secret-bearing adapters (`bigquery, databricks`) plus the Fusion engine job. Triggered by a maintainer (`write+` permission) commenting `/ok-to-test` on a PR, plus `push: main`, a daily schedule, and manual dispatch. Runs in base-repo context so secrets are available; checks out the PR's head SHA (after validating it as a 40-char hex string) and posts commit statuses back to it. Each new push needs a fresh `/ok-to-test` comment.
-- `ci.yml` — delegates to `dbt-labs/dbt-package-testing` reusable workflow. Runs on `push: main` only (the reusable workflow can't be steered at a non-base ref, so running it on PRs would silently re-test main).
+- `ci.yml` — delegates to `dbt-labs/dbt-package-testing` reusable workflow for BigQuery, Databricks, Postgres, Trino. Runs on every PR and push to main.
 
 After pushing, monitor with `gh run list --branch <branch> --limit 5`. If a PR has merge conflicts CI won't trigger — rebase onto `main` first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,10 +82,11 @@ Do **not** use `{{ modules.datetime... }}` for this — the dbt-fusion Jinja eng
 
 ## CI
 
-Two workflows in `.github/workflows/`:
+Three workflows in `.github/workflows/`:
 
-- `ci.yml` — delegates to `dbt-labs/dbt-package-testing` reusable workflow for BigQuery, Databricks, Postgres, Trino.
-- `ci-multiple-dbt-versions.yml` — matrix over `{bigquery, databricks, duckdb, postgres, spark, trino} x {1.10}` plus a Fusion engine job for BigQuery and Databricks.
+- `ci-multiple-dbt-versions.yml` — runs the no-secret adapters (`clickhouse, duckdb, postgres, spark, trino`) on every PR and push. Works the same for fork PRs and same-repo branches because nothing here needs GitHub secrets.
+- `ci-secret-adapters.yml` — runs the secret-bearing adapters (`bigquery, databricks`) plus the Fusion engine job. Triggered by a maintainer (`write+` permission) commenting `/ok-to-test` on a PR, plus `push: main`, a daily schedule, and manual dispatch. Runs in base-repo context so secrets are available; checks out the PR's head SHA (after validating it as a 40-char hex string) and posts commit statuses back to it. Each new push needs a fresh `/ok-to-test` comment.
+- `ci.yml` — delegates to `dbt-labs/dbt-package-testing` reusable workflow. Runs on `push: main` only (the reusable workflow can't be steered at a non-base ref, so running it on PRs would silently re-test main).
 
 After pushing, monitor with `gh run list --branch <branch> --limit 5`. If a PR has merge conflicts CI won't trigger — rebase onto `main` first.
 


### PR DESCRIPTION
Opening this as an alternative to #57. Same goal — let fork PRs run the secret-bearing integration tests without a maintainer pushing a branch — but with a different trigger model.

A maintainer (or any `write+` collaborator) types `/ok-to-test <40-char-sha>` on the PR, naming the specific commit they reviewed. A small `authorize` job checks the commenter's permission, parses the SHA from the comment body, confirms that SHA is reachable from the PR's current head (force-pushed-away or wrong-PR SHAs are rejected with a friendly correction comment), and leaves a confirmation comment with a link to the run. The secret-bearing jobs run in base-repo context with secrets in scope, check out the named SHA, and post commit statuses back to it so the result appears on the PR's Checks tab.

Compared with #57's `workflow_run` cascade:

- One workflow file for the secret half instead of two coupled ones; no implicit dependency on the no-secret workflow completing.
- Trigger is explicit (a comment naming a SHA) rather than implicit (first-time-contributor approval). A maintainer's eyes are on the diff every time secret credentials are about to run, and approval is bound to the specific commit they reviewed.
- Re-runs require a fresh comment per push — chosen deliberately for safety; sticky approval would auto-retest fixup pushes but reduce review tightness.
- Trade-off: maintainer effort per PR is one comment per push, where #57 would have been zero after the initial first-contributor approval.

## Security model

The workflow definition is always the base-branch copy — PRs cannot rewrite it. It does execute fork PR code with warehouse secrets in scope (equivalent to `pull_request_target`). Two gates:

1. `write+` ACL on `/ok-to-test` (the GitHub permission of the commenter is verified before anything else runs).
2. The SHA to run is named explicitly in the comment, then re-verified against the PR's commit history. This closes the TOCTOU race where a fork could push a new commit between the maintainer's comment and the workflow start — only the SHA the maintainer typed gets executed, never live-resolved at run time.

All event-derived strings (`comment.user.login`, `issue.number`, `comment.body`) flow through `env:` rather than being interpolated into shell. The SHA is re-validated as 40-char hex right before being passed to `actions/checkout`'s `ref:` input.

## Also in this PR

- Adds a daily scheduled run for the secret-bearing workflow (offset from the existing no-secret and reusable-workflow schedules) so we catch upstream drift in the secret-bearing adapters too.
- Adds `concurrency:` cancellation so fixup comments cancel earlier runs for the same PR.

## Manual verification needed

- [ ] Confirm `ci-multiple-dbt-versions.yml` runs cleanly on this PR (same-repo branch — no comment needed).
- [ ] Comment `/ok-to-test <sha>` from a `write+` account and confirm the cascade fires, posts a confirmation comment, runs the matrix, and posts statuses back to the SHA.
- [ ] Comment `/ok-to-test` (no SHA) and confirm the workflow rejects it with a friendly correction comment.
- [ ] Comment `/ok-to-test <stale-sha>` (a SHA not in the PR's history) and confirm the workflow rejects it with a comment pointing at the current head.
- [ ] Comment `/ok-to-test <sha>` from an account without `write+` and confirm the authorize job fails fast.

## If accepted

Close #57 — these are mutually exclusive: both workflows on `main` would double-fire on the secret path.