### PR TITLE
dbt lint fix

### DIFF
--- a/macros/calendar_date/convert_timezone.sql
+++ b/macros/calendar_date/convert_timezone.sql
@@ -13,7 +13,7 @@
 {%- endmacro -%}
 
 {%- macro bigquery__convert_timezone(column, target_tz, source_tz=None) -%}
-    timestamp(datetime({{ column }}, '{{ target_tz}}'))
+    timestamp(datetime({{ column }}, '{{ target_tz }}'))
 {%- endmacro -%}
 
 {% macro postgres__convert_timezone(column, target_tz, source_tz) -%}


### PR DESCRIPTION
[dbt lint](https://docs.getdbt.com/reference/commands/lint?version=2.0) expects Jinja tags to have surrounding whitespace:

```
$ dbt lint
...
============================================================================================= Errors and Warnings =============================================================================================
[warning] [JinjaPadding (dbt0175)]: Jinja tags should have a single whitespace on either side: {{ target_tz}} [JJ01]
  --> dbt_packages/dbt_date/macros/calendar_date/convert_timezone.sql:16:39

============================================================================================== Execution Summary ==============================================================================================
Finished 'lint' with 1 warning
```