### PR TITLE
Pin month-relative integration tests to a frozen reference date

### DIFF
--- a/integration_tests/macros/get_test_dates.sql
+++ b/integration_tests/macros/get_test_dates.sql
@@ -33,7 +33,12 @@
         ) as time_stamp_utc,
         cast('2021-06-07' as {{ dbt.type_timestamp() }}) as rounded_timestamp,
         cast('2021-06-08' as {{ dbt.type_timestamp() }}) as rounded_timestamp_utc,
-        -- These columns are here to make sure these macros get run during testing:
+        -- These columns are here to make sure these macros get run during testing.
+        -- as_of_date freezes today() at `dbt run` time so the month-relative
+        -- assertions in test_dates.yml derive their expected values from this stored
+        -- date rather than a fresh today() at `dbt test` time. Without it, a run and
+        -- test that straddle a month boundary (in the configured time zone) disagree.
+        {{ dbt_date.today() }} as as_of_date,
         {{ dbt_date.last_month_number() }} as last_month_number,
         {{ dbt_date.last_month_name(short=False) }} as last_month_name,
         {{ dbt_date.last_month_name(short=True) }} as last_month_name_short,
@@ -81,7 +86,12 @@
         ) as time_stamp_utc,
         cast('2021-06-07' as {{ dbt.type_timestamp() }}) as rounded_timestamp,
         cast('2021-06-08' as {{ dbt.type_timestamp() }}) as rounded_timestamp_utc,
-        -- These columns are here to make sure these macros get run during testing:
+        -- These columns are here to make sure these macros get run during testing.
+        -- as_of_date freezes today() at `dbt run` time so the month-relative
+        -- assertions in test_dates.yml derive their expected values from this stored
+        -- date rather than a fresh today() at `dbt test` time. Without it, a run and
+        -- test that straddle a month boundary (in the configured time zone) disagree.
+        {{ dbt_date.today() }} as as_of_date,
         {{ dbt_date.last_month_number() }} as last_month_number,
         {{ dbt_date.last_month_name(short=False) }} as last_month_name,
         {{ dbt_date.last_month_name(short=True) }} as last_month_name_short,

--- a/integration_tests/models/test_dates.yml
+++ b/integration_tests/models/test_dates.yml
@@ -88,22 +88,22 @@ models:
             expression: "rounded_timestamp_utc = {{ dbt_date.round_timestamp('time_stamp_utc') }}"
       - expression_is_true:
           arguments:
-            expression: "last_month_number = {{ dbt_date.last_month_number() }}"
+            expression: "last_month_number = {{ dbt_date.date_part('month', dbt.date_trunc('month', dbt.dateadd('month', -1, 'as_of_date'))) }}"
       - expression_is_true:
           arguments:
-            expression: "last_month_name = {{ dbt_date.last_month_name(short=False) }}"
+            expression: "last_month_name = {{ dbt_date.month_name(dbt.date_trunc('month', dbt.dateadd('month', -1, 'as_of_date')), short=False) }}"
       - expression_is_true:
           arguments:
-            expression: "last_month_name_short = {{ dbt_date.last_month_name(short=True) }}"
+            expression: "last_month_name_short = {{ dbt_date.month_name(dbt.date_trunc('month', dbt.dateadd('month', -1, 'as_of_date')), short=True) }}"
       - expression_is_true:
           arguments:
-            expression: "next_month_number = {{ dbt_date.next_month_number() }}"
+            expression: "next_month_number = {{ dbt_date.date_part('month', dbt.date_trunc('month', dbt.dateadd('month', 1, 'as_of_date'))) }}"
       - expression_is_true:
           arguments:
-            expression: "next_month_name = {{ dbt_date.next_month_name(short=False) }}"
+            expression: "next_month_name = {{ dbt_date.month_name(dbt.date_trunc('month', dbt.dateadd('month', 1, 'as_of_date')), short=False) }}"
       - expression_is_true:
           arguments:
-            expression: "next_month_name_short = {{ dbt_date.next_month_name(short=True) }}"
+            expression: "next_month_name_short = {{ dbt_date.month_name(dbt.date_trunc('month', dbt.dateadd('month', 1, 'as_of_date')), short=True) }}"
       - expression_is_true:
           arguments:
             expression: "datetime_date = cast('{{ dbt_date.date(1997, 9, 29) }}' as date)"


### PR DESCRIPTION
The `duckdb` integration tests failed intermittently (e.g. [run 28499584995](https://github.com/godatadriven/dbt-date/actions/runs/28499584995/job/84473526716)) on the six month-relative assertions — `last_month_number`, `last_month_name`, `last_month_name_short`, `next_month_number`, `next_month_name`, `next_month_name_short` — and then passed on re-run with no code changes. This is a month-boundary race, not a real regression.

The `last_month_*` / `next_month_*` macros compile to SQL anchored on `current_date` (via `dbt_date.today(tz)`). The integration project materialises models as `table` and sets `dbt_date:time_zone: "America/Los_Angeles"`. So the model column is frozen at `dbt run` time, while `test_dates.yml` re-evaluated the same macros at `dbt test` time. When the two steps straddle midnight-of-the-1st in that time zone (07:00–08:00 UTC depending on DST), they resolve to different months and the assertion fails. The failing run built the model at 23:59:56 PDT (June 30) and asserted at 00:00:01 PDT (July 1); the re-run ran entirely on one side of the boundary, so it was green.

This pins the reference date so the two invocations can't disagree: `get_test_dates.sql` now captures `today()` once as a frozen `as_of_date` column (evaluated in the same statement as the month columns, so it shares their exact instant), and the six assertions in `test_dates.yml` derive their expected values from that stored column via `dbt.date_trunc` / `dbt.dateadd` instead of a fresh `today()`. The macros are still exercised at `dbt run` time, so coverage is unchanged.

Verified locally with `tox -e dbt_integration_duckdb`: 36/36 tests pass.
