### PR TITLE
ci: skip Package Integration Tests on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ on:
 
 jobs:
   run-tests:
+    # This workflow needs warehouse secrets, which GitHub withholds from
+    # fork PRs — so it can only pass on same-repo refs. Skip it on fork PRs
+    # (they get no-secret coverage from ci-multiple-dbt-versions.yml and
+    # secret-adapter coverage via `/ok-to-test` in ci-secret-adapters.yml).
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox.yml@v1
     permissions:
       contents: read


### PR DESCRIPTION
`ci.yml` (Package Integration Tests) calls the `dbt-labs/dbt-package-testing` reusable workflow with warehouse secrets (BigQuery, Databricks, Trino). GitHub withholds secrets from fork PRs, so its bigquery/databricks jobs always fail there — leaving a misleading red X on the PR even when the change is sound (as just seen on #41).

This guards the job so it only runs where secrets are available: `push` to main, `schedule`, `workflow_dispatch`, and same-repo PRs. Fork PRs skip it (a skipped job is neutral, not a red X) and are still fully covered — no-secret adapters run automatically via `ci-multiple-dbt-versions.yml`, and the secret-bearing adapters run with secrets in scope via `/ok-to-test` in `ci-secret-adapters.yml`.

No change to same-repo PR behaviour.
