### PR TITLE
ci: bump checkout and setup-python off deprecated Node 20

### DIFF
--- a/.github/workflows/ci-multiple-dbt-versions.yml
+++ b/.github/workflows/ci-multiple-dbt-versions.yml
@@ -65,7 +65,7 @@ jobs:
           - "1.10"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -73,7 +73,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: .python-version
 
@@ -138,7 +138,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -146,7 +146,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: .python-version
 

--- a/.github/workflows/ci-secret-adapters.yml
+++ b/.github/workflows/ci-secret-adapters.yml
@@ -170,7 +170,7 @@ jobs:
       # (3) the SHA being regex-validated as 40-char hex before being passed to
       # `ref:`. See the security model comment at the top of this file.
       # codeql[actions/untrusted-checkout/high]
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.authorize.outputs.head_sha }}
 
@@ -180,7 +180,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: .python-version
 

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Fetch tags
         run: git fetch --prune --unshallow --tags


### PR DESCRIPTION
The `/ok-to-test` secret-adapter run surfaced Node.js 20 deprecation warnings: GitHub is forcing `actions/checkout@v4` and `actions/setup-python@v5` onto Node 24 because Node 20 is end-of-life on the runners.

This bumps both to the first majors that natively target Node 24, clearing the warnings across `ci-multiple-dbt-versions.yml`, `ci-secret-adapters.yml`, and `release-pipeline.yml`:

- `actions/checkout@v4` → `@v5`
- `actions/setup-python@v5` → `@v6`

Deliberately staying on `checkout@v5` rather than the latest `@v7`: v7 blocks checking out fork PRs in privileged event contexts, which could break the `/ok-to-test` flow in `ci-secret-adapters.yml` (it checks out a maintainer-named fork SHA with secrets in scope). v5 is the minimal, lowest-risk bump that resolves the deprecation — its only change from v4 is the Node 24 runtime and a newer minimum runner version.
