### PR TITLE
ci: add dbt-core 1.11 and 1.12 to the test matrix where available

### DIFF
--- a/.github/workflows/ci-multiple-dbt-versions.yml
+++ b/.github/workflows/ci-multiple-dbt-versions.yml
@@ -61,6 +61,15 @@ jobs:
           - trino
         dbt-version:
           - "1.10"
+          - "1.11"
+        # clickhouse and trino have no dbt-core 1.11 compatible release yet,
+        # so exclude those combinations. No 1.12 release exists for any of
+        # these adapters. Revisit when upstream publishes them.
+        exclude:
+          - adapter: clickhouse
+            dbt-version: "1.11"
+          - adapter: trino
+            dbt-version: "1.11"
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci-secret-adapters.yml
+++ b/.github/workflows/ci-secret-adapters.yml
@@ -155,9 +155,7 @@ jobs:
         dbt-version:
           - "1.10"
           - "1.11"
-        # include:
-        #   - adapter: databricks
-        #     dbt-version: "1.12"
+          - "1.12"
 
     steps:
       # CodeQL flags this checkout as "untrusted code in privileged context".

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 	<img src="https://img.shields.io/github/v/tag/godatadriven/dbt-date?logo=github">
-  <img src="https://img.shields.io/badge/dbt--core-%3E=1.6%20%3C=1.10.x-orange?logo=dbt">
+  <img src="https://img.shields.io/badge/dbt--core-%3E=1.6%20%3C=1.12.x-orange?logo=dbt">
 	<img src="https://img.shields.io/badge/license-Apache--2.0-ff69b4?style=plastic">
   <img src="https://img.shields.io/github/last-commit/godatadriven/dbt-date/main">
 </div>


### PR DESCRIPTION
Extends the integration test matrix to newer dbt-core minors, adding each version only for adapters that actually publish a compatible release (`--prerelease allow` lets release candidates resolve, matching the existing `~=X.0a0` pins).

No-secret adapters (`ci-multiple-dbt-versions.yml`): add `1.11` for duckdb, postgres and spark. clickhouse and trino have no dbt-core 1.11 release yet, so those combinations are excluded via the matrix. No adapter in this set has a 1.12 release, so 1.12 is not added here.

Secret adapters (`ci-secret-adapters.yml`): add `1.12` for bigquery and databricks — both now publish a 1.12 release — replacing the stale commented-out databricks-only `include`.

The README dbt-core badge upper bound is bumped from `1.10.x` to `1.12.x`.

Adapter availability at time of writing:

| Adapter | 1.11 | 1.12 |
| --- | --- | --- |
| clickhouse | none | none |
| duckdb | 1.11.0 | none |
| postgres | 1.11.0rc1 | none |
| spark | 1.11.0rc1 | none |
| trino | none | none |
| bigquery | 1.11.x | 1.12.0 |
| databricks | 1.11.x | 1.12.x |

The secret-adapter jobs only run when a maintainer comments `/ok-to-test <sha>`, so the bigquery/databricks 1.12 additions are not exercised by this PR's automatic checks.
